### PR TITLE
Implement Wellcome HK web scraper and fix pyproject.toml

### DIFF
--- a/products/spiders/wellcome_hk.py
+++ b/products/spiders/wellcome_hk.py
@@ -1,0 +1,25 @@
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class WellcomeHKSpider(CrawlSpider, StructuredDataSpider):
+    name = "wellcome_hk"
+    allowed_domains = ["wellcome.com.hk"]
+    start_urls = ["https://www.wellcome.com.hk/en/wellcome/category/100011/1.html"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q706247",
+                "name": "Wellcome",
+            }
+        }
+    }
+
+    rules = (
+        Rule(LinkExtractor(allow=r"/en/wellcome/category/\d+/\d+\.html")),
+        Rule(LinkExtractor(allow=r"/en/wellcome/p/[^/]+/i/\d+\.html"), callback="parse_sd"),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ dependencies = [
     "xmltodict",
 ]
 
-[tool.uv]
-dependency-groups.dev = [ "autoflake8",
+[dependency-groups]
+dev = [
+    "autoflake8",
     "awscli",
     "black",
     "boto3",
@@ -47,6 +48,8 @@ dependency-groups.dev = [ "autoflake8",
     "pylint",
     "pytest",
 ]
+
+[tool.uv]
 
 [[tool.uv.index]]
 name = "pypi"


### PR DESCRIPTION
This PR implements a web scraper for Wellcome Hong Kong (wellcome.com.hk) as requested in issue #172. 

The implementation uses the `StructuredDataSpider` mixin to automatically extract JSON-LD and Microdata from product pages. It also fixes a syntax error in `pyproject.toml` that was preventing `uv run` from functioning correctly due to an incorrectly placed `dependency-groups` section.

Testing:
- Verified that `uv run scrapy list` works after the fix.
- Verified structured data extraction with `uv run scrapy sd <wellcome_product_url>`.
- Ran a test crawl with `uv run scrapy crawl wellcome_hk -s CLOSESPIDER_ITEMCOUNT=10` and confirmed correct data extraction.

---
*PR created automatically by Jules for task [1372222122371574521](https://jules.google.com/task/1372222122371574521) started by @CloCkWeRX*