### PR TITLE
Add Wellcome HK spider and fix pyproject.toml

### DIFF
--- a/products/spiders/wellcome_hk.py
+++ b/products/spiders/wellcome_hk.py
@@ -1,0 +1,19 @@
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from products.structured_data_spider import StructuredDataSpider
+
+class WellcomeHKSpider(CrawlSpider, StructuredDataSpider):
+    name = "wellcome_hk"
+    allowed_domains = ["wellcome.com.hk"]
+    start_urls = ["https://www.wellcome.com.hk/zh-hant/"]
+
+    rules = (
+        Rule(LinkExtractor(allow=r"/p/.+/i/.+\.html"), callback="parse_sd"),
+        Rule(LinkExtractor(allow=r"/category/")),
+    )
+
+    item_attributes = {
+        "extras": {
+            "seller": {"@type": "Organization", "name": "Wellcome"}
+        }
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ dependencies = [
     "xmltodict",
 ]
 
-[tool.uv]
-dependency-groups.dev = [ "autoflake8",
+[dependency-groups]
+dev = [
+    "autoflake8",
     "awscli",
     "black",
     "boto3",


### PR DESCRIPTION
Fix #172 

This PR implements a new web scraper for Wellcome HK (issue #172) and fixes a configuration error in `pyproject.toml`.

- **Wellcome HK Spider**: Implemented `WellcomeHKSpider` in `products/spiders/wellcome_hk.py`. It uses `CrawlSpider` with rules to discover products and categories, and `StructuredDataSpider` to extract schema.org metadata.
- **pyproject.toml Fix**: Moved `dependency-groups` from `[tool.uv]` to the top level to resolve a `uv` parsing error.

Verification:
- Successfully ran `uv run scrapy sd <wellcome_url>` to verify structured data extraction.
- Successfully ran `uv run scrapy crawl wellcome_hk` to verify discovery and scraping of items.
- Ran `uv run scrapy check wellcome_hk` to ensure spider validity.

---
*PR created automatically by Jules for task [3794803587828034134](https://jules.google.com/task/3794803587828034134) started by @CloCkWeRX*