### PR TITLE
Implement Savegnago Supermercados spider

### DIFF
--- a/products/spiders/savegnago_br.py
+++ b/products/spiders/savegnago_br.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class SavegnagoBRSpider(SitemapSpider, StructuredDataSpider):
+    name = "savegnago_br"
+    allowed_domains = ["savegnago.com.br"]
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q121097894",
+                "name": "Savegnago Supermercados",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.savegnago.com.br/sitemap.xml"]
+    sitemap_rules = [
+        (r"https://www.savegnago.com.br/[\w-]+/p", "parse_sd"),
+    ]


### PR DESCRIPTION
Fix #164 

I have implemented a new spider for Savegnago Supermercados (savegnago.com.br).

Key changes:
- Created `products/spiders/savegnago_br.py` using `SitemapSpider` and `StructuredDataSpider`.
- Configured sitemap URLs and rules to target product pages.
- Added Wikidata ID `Q121097894` for Savegnago Supermercados to the spider's `item_attributes`.
- Verified the spider's configuration with `scrapy check` and its functionality by running a sample crawl.

The spider correctly extracts product information and associates it with the Savegnago Wikidata entity.

---
*PR created automatically by Jules for task [9824350298598042983](https://jules.google.com/task/9824350298598042983) started by @CloCkWeRX*