### PR TITLE
Add Tottus spider (Chile and Peru) for issue #169

### DIFF
--- a/products/spiders/tottus.py
+++ b/products/spiders/tottus.py
@@ -1,0 +1,26 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class TottusSpider(SitemapSpider, StructuredDataSpider):
+    name = "tottus"
+    allowed_domains = ["tottus.cl", "tottus.com.pe", "tottus.com"]
+    item_attributes = {
+        "brand_wikidata": "Q7828510",
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q7828510",
+                "name": "Tottus",
+            }
+        }
+    }
+
+    sitemap_urls = [
+        "https://www.tottus.cl/robots.txt",
+        "https://www.tottus.com.pe/robots.txt",
+    ]
+    sitemap_rules = [
+        (r"/articulo/", "parse_sd"),
+    ]


### PR DESCRIPTION
I have implemented a new Scrapy spider for Tottus, a major supermarket chain in Chile and Peru, as requested in issue #169.

Key features:
- Uses `SitemapSpider` for product discovery via `robots.txt` and `StructuredDataSpider` for metadata extraction from schema.org terms.
- Supports `www.tottus.cl` and `www.tottus.com.pe`.
- Includes the Wikidata ID (`Q7828510`) for proper brand identification.
- Verified with `uv run scrapy check tottus` and sample crawls on both domains.

---
*PR created automatically by Jules for task [8105652229265621259](https://jules.google.com/task/8105652229265621259) started by @CloCkWeRX*