### PR TITLE
Add Pão de Açúcar (Brazil) spider

### DIFF
--- a/products/spiders/paodeacucar_br.py
+++ b/products/spiders/paodeacucar_br.py
@@ -1,0 +1,59 @@
+import json
+
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class PaodeacucarBRSpider(CrawlSpider, StructuredDataSpider):
+    name = "paodeacucar_br"
+    allowed_domains = ["paodeacucar.com"]
+    start_urls = ["https://www.paodeacucar.com/categoria/alimentos/hortifruti"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q3411543",
+                "name": "Pão de Açúcar",
+            }
+        }
+    }
+
+    rules = (
+        Rule(LinkExtractor(allow=r"/produto/\d+/[\w-]+"), callback="parse_sd"),
+        Rule(LinkExtractor(allow=(r"/categoria/[\w-]+", r"/secoes/C\d+/[\w-]+"))),
+    )
+
+    def parse_start_url(self, response, **kwargs):
+        yield from self.extract_next_data_links(response)
+
+    def parse_sd(self, response, **kwargs):
+        yield from self.extract_next_data_links(response)
+        yield from super().parse_sd(response)
+
+    def extract_next_data_links(self, response):
+        next_data_script = response.xpath('//script[@id="__NEXT_DATA__"]/text()').get()
+        if next_data_script:
+            try:
+                data = json.loads(next_data_script)
+                links = self._find_links(data)
+                for link in links:
+                    yield response.follow(link)
+            except Exception:
+                self.logger.exception("Failed to parse __NEXT_DATA__")
+
+    def _find_links(self, obj):
+        links = set()
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k in ["uiLink", "link", "urlDetails"] and isinstance(v, str):
+                    if v.startswith("/produto/") or v.startswith("/categoria/") or v.startswith("/secoes/"):
+                        links.add(v)
+                else:
+                    links.update(self._find_links(v))
+        elif isinstance(obj, list):
+            for item in obj:
+                links.update(self._find_links(item))
+        return links

--- a/products/structured_data_spider.py
+++ b/products/structured_data_spider.py
@@ -73,7 +73,8 @@ class StructuredDataSpider(Spider):
     search_for_image = True
     json_parser = "json"
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         for i, wanted in enumerate(self.wanted_types):
             if isinstance(wanted, list):
                 self.wanted_types[i] = [LinkedDataParser.clean_type(t) for t in wanted]


### PR DESCRIPTION
This PR implements a new spider for the Pão de Açúcar (Brazil) supermarket chain.

Key changes:
1.  **New Spider**: Added `paodeacucar_br.py` using `CrawlSpider` and `StructuredDataSpider`. It includes custom logic to parse the `__NEXT_DATA__` JSON block, which is essential for link discovery on this Next.js-based site.
2.  **Base Class Fix**: Modified `StructuredDataSpider.__init__` to correctly handle and pass `*args` and `**kwargs` to the parent `Spider` class. This fix was necessary to allow `CrawlSpider` (or other Scrapy spider types) to be used as a base class alongside `StructuredDataSpider`.
3.  **Wikidata Integration**: Included the official Wikidata ID (`Q3411543`) for Pão de Açúcar in the item attributes.

The spider's ability to extract product data was verified using the `scrapy sd` command on individual product pages. `scrapy check` also passes for the new spider.

---
*PR created automatically by Jules for task [16981757097034160512](https://jules.google.com/task/16981757097034160512) started by @CloCkWeRX*