### PR TITLE
Add Eataly spider for structured data extraction

### DIFF
--- a/products/spiders/eataly_com.py
+++ b/products/spiders/eataly_com.py
@@ -1,0 +1,27 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class EatalyComSpider(SitemapSpider, StructuredDataSpider):
+    name = "eataly_com"
+    allowed_domains = ["eataly.com"]
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q3046645",
+                "name": "Eataly",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.eataly.com/robots.txt"]
+    sitemap_rules = [
+        (r"https://www.eataly.com/us_en/[^/]+$", "parse_sd"),
+        (r"https://www.eataly.com/[^/]+$", "parse_sd"),
+    ]
+
+    custom_settings = {
+        "CLOSESPIDER_TIMEOUT": 120,
+    }


### PR DESCRIPTION
This PR adds a new web scraper for Eataly.com.

Features:
- Discovery via sitemaps (starting from robots.txt).
- Extraction of schema.org Product data via JSON-LD.
- Wikidata integration (Q3046645).
- 2-minute execution timeout to avoid large sitemap downloads.

Fix #128

Sample output:
```json
{
 'extras': {},
 'image': 'https://www.eataly.com/media/catalog/product/u/n/untitled_design_1__6_2.png',
 'name': 'A Taste of Love for Two Gift Box',
 'offers': [{'@type': 'Offer',
             'availability': 'InStock',
             'price': '234.99',
             'priceCurrency': 'USD',
             'seller': {'@type': 'Organization', 'name': 'Eataly'},
             'url': 'https://www.eataly.com/us_en/a-taste-of-love-for-two-gift-box'}],
 'ref': 'https://www.eataly.com/us_en/a-taste-of-love-for-two-gift-box',
 'website': 'https://www.eataly.com/us_en/a-taste-of-love-for-two-gift-box'
}
```

---
*PR created automatically by Jules for task [5780815124128461007](https://jules.google.com/task/5780815124128461007) started by @CloCkWeRX*