### PR TITLE
Add coopfirenze_it spider

### DIFF
--- a/products/spiders/coopfirenze_it.py
+++ b/products/spiders/coopfirenze_it.py
@@ -23,10 +23,6 @@ class CoopFirenzeSpider(SitemapSpider, StructuredDataSpider):
         }
     }
 
-    custom_settings = {
-        "CLOSESPIDER_TIMEOUT": 120,
-    }
-
     product_extractor = LinkExtractor(
         allow=r"/[0-9]{13}\.html",
     )

--- a/products/spiders/coopfirenze_it.py
+++ b/products/spiders/coopfirenze_it.py
@@ -1,0 +1,36 @@
+from scrapy.spiders import SitemapSpider
+from scrapy.linkextractors import LinkExtractor
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class CoopFirenzeSpider(SitemapSpider, StructuredDataSpider):
+    name = "coopfirenze_it"
+    allowed_domains = ["prenotalaspesa.coopfirenze.it"]
+    sitemap_urls = ["https://prenotalaspesa.coopfirenze.it/robots.txt"]
+    sitemap_rules = [
+        (r"/[0-9]{13}\.html", "parse_sd"),
+        (r"/", "parse_category"),
+    ]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q4004707",
+                "name": "Unicoop Firenze",
+            }
+        }
+    }
+
+    custom_settings = {
+        "CLOSESPIDER_TIMEOUT": 120,
+    }
+
+    product_extractor = LinkExtractor(
+        allow=r"/[0-9]{13}\.html",
+    )
+
+    def parse_category(self, response):
+        for link in self.product_extractor.extract_links(response):
+            yield response.follow(link, callback=self.parse_sd)


### PR DESCRIPTION
Fix #122 

Implemented a Scrapy spider for Unicoop Firenze (https://prenotalaspesa.coopfirenze.it/).
The spider inherits from SitemapSpider and StructuredDataSpider.
It extracts schema.org terms from product pages.
Includes Wikidata ID Q4004707 for the seller.
Added a 2-minute execution timeout.
Verified with sample product URLs and short crawl.

---
*PR created automatically by Jules for task [3598636320822380001](https://jules.google.com/task/3598636320822380001) started by @CloCkWeRX*