### PR TITLE
Add Schnucks spider

### DIFF
--- a/products/spiders/schnucks.py
+++ b/products/spiders/schnucks.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class SchnucksSpider(SitemapSpider, StructuredDataSpider):
+    name = "schnucks"
+    allowed_domains = ["schnucks.com"]
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q7431920",
+                "name": "Schnucks",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://schnucks.com/robots.txt"]
+    sitemap_rules = [
+        (r"https://schnucks\.com/products/(\d+)", "parse_sd"),
+    ]


### PR DESCRIPTION
Implemented a web scraper for Schnucks (schnucks.com) as requested in issue #60.

Key features:
- Inherits from `SitemapSpider` and `StructuredDataSpider`.
- Uses `robots.txt` to discover sitemaps.
- Targets product pages using the pattern `https://schnucks.com/products/(\d+)`.
- Injects Wikidata ID `Q7431920` and seller name into scraped items via `item_attributes`.
- Successfully verified with a 100+ item crawl.

Fix #60

---
*PR created automatically by Jules for task [5250745204776027678](https://jules.google.com/task/5250745204776027678) started by @CloCkWeRX*