### PR TITLE
Add Hy-Vee spider for issue #142

### DIFF
--- a/products/spiders/hy_vee.py
+++ b/products/spiders/hy_vee.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class HyVeeSpider(SitemapSpider, StructuredDataSpider):
+    name = "hy_vee"
+    allowed_domains = ["hy-vee.com"]
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q1639719",
+                "name": "Hy-Vee",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.hy-vee.com/sitemap-aisles-online-products-index.xml"]
+    sitemap_rules = [
+        (r"/aisles-online/p/(\d+)", "parse_sd"),
+    ]


### PR DESCRIPTION
Implemented a new Scrapy spider for Hy-Vee inheriting from SitemapSpider and StructuredDataSpider. The spider uses the product sitemap index to discover products and extracts structured data (Schema.org) from product pages. Added Wikidata ID Q1639719 for the seller.

Sample output:
```json
{
  "extras": {
    "@source_uri": "https://www.hy-vee.com/aisles-online/p/23407/hy-vee-unsalted-tops-saltine-crackers",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q1639719",
      "@type": "Organization",
      "name": "Hy-Vee"
    }
  },
  "image": "https://e22d0640933e3c7f8c86-34aee0c49088be50e3ac6555f6c963fb.ssl.cf2.rackcdn.com/505a9e5a-44e0-4900-89dc-1f6cf8d7fb6d_large.png",
  "name": "Hy-Vee Unsalted Tops Saltine Crackers",
  "offers": [
    {
      "@type": "Offer",
      "availability": "https://schema.org/InStock",
      "itemCondition": "https://schema.org/NewCondition",
      "price": "2.99",
      "priceCurrency": "USD",
      "seller": {
        "@type": "Organization",
        "name": "Hy-Vee"
      },
      "url": "https://www.hy-vee.com/aisles-online/p/23407/hy-vee-unsalted-tops-saltine-crackers"
    }
  ],
  "ref": "23407",
  "website": "https://www.hy-vee.com/aisles-online/p/23407/hy-vee-unsalted-tops-saltine-crackers"
}
```

Fix #142

---
*PR created automatically by Jules for task [16822332490784687059](https://jules.google.com/task/16822332490784687059) started by @CloCkWeRX*