### PR TITLE
Add Continente (Portugal) spider

### DIFF
--- a/products/spiders/continente_pt.py
+++ b/products/spiders/continente_pt.py
@@ -1,0 +1,32 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import BROWSER_DEFAULT
+
+
+class ContinentePTSpider(SitemapSpider, StructuredDataSpider):
+    name = "continente_pt"
+    allowed_domains = ["continente.pt"]
+    user_agent = BROWSER_DEFAULT
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q2995683",
+                "name": "Continente",
+            }
+        }
+    }
+
+    sitemap_urls = [
+        "https://www.continente.pt/sitemap-custom_sitemap_1-product.xml",
+        "https://www.continente.pt/sitemap-custom_sitemap_12-product.xml",
+        "https://www.continente.pt/sitemap-custom_sitemap_16-product.xml",
+        "https://www.continente.pt/sitemap-custom_sitemap_20-product.xml",
+        "https://www.continente.pt/sitemap-custom_sitemap_4-product.xml",
+        "https://www.continente.pt/sitemap-custom_sitemap_8-product.xml",
+    ]
+    sitemap_rules = [
+        (r"/produto/.*-(\d+)\.html", "parse"),
+    ]


### PR DESCRIPTION
Fix #119 
Implemented a Scrapy spider for Continente Portugal (continente.pt) using SitemapSpider and StructuredDataSpider. 
 
- Added Wikidata ID Q2995683 for Continente.
- Configured sitemap discovery targeting product sitemaps to avoid full sitemap overhead.
- Verified structured data extraction on several products.
 
Sample Output:
```json
{
  "extras": {
    "@source_uri": "https://www.continente.pt/produto/leite-uht-meio-gordo-continente-continente-7062996.html",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q2995683",
      "@type": "Organization",
      "name": "Continente"
    }
  },
  "image": "https://www.continente.pt/dw/image/v2/BDVS_PRD/on/demandware.static/-/Sites-col-master-catalog/default/dw47710c7a/images/col/706/7062996-hero.jpg?sw=280&sh=280",
  "name": "Leite UHT Meio Gordo Continente",
  "offers": [
    {
      "@type": "Offer",
      "availability": "http://schema.org/InStock",
      "price": "0.94",
      "priceCurrency": "EUR",
      "priceValidUntil": "2027-06-17",
      "url": {}
    }
  ],
  "ref": "7062996",
  "website": "https://www.continente.pt/produto/leite-uht-meio-gordo-continente-continente-7062996.html"
}
```

---
*PR created automatically by Jules for task [16650261297694260074](https://jules.google.com/task/16650261297694260074) started by @CloCkWeRX*