### PR TITLE
Add Combi (Germany) spider

### DIFF
--- a/products/spiders/combi_de.py
+++ b/products/spiders/combi_de.py
@@ -1,0 +1,55 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import BROWSER_DEFAULT
+
+
+class CombiDESpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Combi (Germany).
+
+    Sample output:
+    {
+        'extras': {
+            'seller': {
+                '@type': 'Organization',
+                '@id': 'https://www.wikidata.org/wiki/Q1113618',
+                'name': 'Combi'
+            }
+        },
+        'image': 'https://d2y99t05v0nd2u.cloudfront.net/products/images/4507010015_2099990155232.jpg.jpg',
+        'name': 'Lauchzwiebeln im Bund',
+        'offers': [{
+            '@type': 'Offer',
+            'availability': 'https://schema.org/InStock',
+            'itemCondition': 'https://schema.org/NewCondition',
+            'priceSpecification': {
+                '@type': 'UnitPriceSpecification',
+                'price': '1.29',
+                'priceCurrency': 'EUR',
+                'valueAddedTaxIncluded': True
+            }
+        }],
+        'ref': '4507010015',
+        'website': 'https://www.combi.de/lauchzwiebeln_im_bund_4507010015.html'
+    }
+    """
+
+    name = "combi_de"
+    allowed_domains = ["combi.de"]
+    user_agent = BROWSER_DEFAULT
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q1113618",
+                "name": "Combi",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.combi.de/sitemaps/combi/sitemap.produkte.xml"]
+    sitemap_rules = [
+        (r"/.*_(\d+)\.html$", "parse_sd"),
+    ]


### PR DESCRIPTION
Fix #214 
Implemented a new Scrapy spider for Combi (Germany) in `products/spiders/combi_de.py`.

Key features:
- Inherits from `SitemapSpider` and `StructuredDataSpider` for efficient discovery and extraction.
- Targets the specific product sitemap (`sitemap.produkte.xml`) to avoid unnecessary overhead.
- Injects Wikidata ID `Q1113618` and seller name "Combi" into extracted items.
- Automatically captures product references (refs) from the URL pattern.

Sample output structured data:
```json
{
    "extras": {
        "@source_uri": "https://www.combi.de/mr._low_und_co._dressing_1000_island_4502085033.html",
        "seller": {
            "@type": "Organization",
            "@id": "https://www.wikidata.org/wiki/Q1113618",
            "name": "Combi"
        }
    },
    "name": "Mr. Low & Co. Dressing 1000 Island",
    "website": "https://www.combi.de/mr._low_und_co._dressing_1000_island_4502085033.html",
    "image": "https://d2y99t05v0nd2u.cloudfront.net/products/images/4502085033_4260126428843_01.jpg",
    "ref": "4502085033",
    "offers": [
        {
            "@type": "Offer",
            "availability": "https://schema.org/InStock",
            "itemCondition": "https://schema.org/NewCondition",
            "priceSpecification": {
                "@type": "UnitPriceSpecification",
                "price": "2.89",
                "priceCurrency": "EUR",
                "valueAddedTaxIncluded": true
            }
        }
    ]
}
```

Fix #118

---
*PR created automatically by Jules for task [12009216865766046032](https://jules.google.com/task/12009216865766046032) started by @CloCkWeRX*