### PR TITLE
Add Carulla (Colombia) spider for issue #112

### DIFF
--- a/products/spiders/carulla_com.py
+++ b/products/spiders/carulla_com.py
@@ -1,0 +1,58 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class CarullaComSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Carulla (Colombia).
+    Wikidata: Q5047464
+
+    Sample output structured data:
+    {
+      "name": "Soda BRETANA botella vidrio x12und  (3600  ml)",
+      "brand": "BRETANA",
+      "image": "https://carulla.vtexassets.com/arquivos/ids/24719590/Of-Soda-Pague-9-Lleve-12-1443507_a.jpg?v=639095354124670000",
+      "ref": "1443507",
+      "offers": [
+        {
+          "@type": "Offer",
+          "price": 29500,
+          "priceCurrency": "COP",
+          "availability": "https://schema.org/InStock",
+          "itemCondition": "https://schema.org/NewCondition",
+          "url": "https://www.carulla.com/of-soda-pague-9-lleve-12-365350/p",
+          "seller": {
+            "@type": "Organization",
+            "name": "carulla"
+          }
+        }
+      ],
+      "website": "https://www.carulla.com/of-soda-pague-9-lleve-12-365350/p",
+      "extras": {
+        "seller": {
+          "@type": "Organization",
+          "@id": "https://www.wikidata.org/wiki/Q5047464",
+          "name": "Carulla"
+        }
+      }
+    }
+    """
+
+    name = "carulla_com"
+    allowed_domains = ["carulla.com"]
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q5047464",
+                "name": "Carulla",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.carulla.com/robots.txt"]
+    sitemap_rules = [
+        (r"/.*-(\d+)/p$", "parse_sd"),
+        (r"/p$", "parse_sd"),
+    ]


### PR DESCRIPTION
I have implemented a new Scrapy spider for Carulla (Colombia), addressing issue #112. 

The spider:
- Inherits from `SitemapSpider` for efficient product discovery via `robots.txt` and XML sitemaps.
- Inherits from `StructuredDataSpider` to automatically extract `schema.org` data (JSON-LD).
- Includes the correct Wikidata ID (`Q5047464`) for the retailer.
- Follows repository naming conventions.

I verified the implementation by:
1. Running `uv run scrapy sd` on a sample product URL to confirm valid structured data extraction.
2. Running a full crawl with a 2-minute timeout (`-s CLOSESPIDER_TIMEOUT=120`) to verify sitemap discovery and successful scraping of multiple items.
3. Running the naming consistency check script.

Sample output data is included in the class docstring for reference. All temporary test files and HTML dumps have been removed.

---
*PR created automatically by Jules for task [1967489859122339130](https://jules.google.com/task/1967489859122339130) started by @CloCkWeRX*