### PR TITLE
Add Chedraui (Mexico) spider for issue #116

### DIFF
--- a/products/spiders/chedraui_com_mx.py
+++ b/products/spiders/chedraui_com_mx.py
@@ -1,0 +1,62 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import BROWSER_DEFAULT
+
+
+class ChedrauiComMXSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Chedraui (Mexico).
+    Wikidata: Q2961952
+
+    Sample output structured data:
+    {
+        "name": "Avena Bob's Red Mill Orgánica Estilo Escocés 567g",
+        "website": "https://www.chedraui.com.mx/avena-bobs-red-mill-organica-estilo-escoces-567g-3344281/p",
+        "image": "https://chedrauimx.vtexassets.com/arquivos/ids/70006182/39978029560_00.jpg?v=639150049591370000",
+        "ref": "03344281",
+        "offers": [
+            {
+                "@type": "AggregateOffer",
+                "lowPrice": 229,
+                "highPrice": 229,
+                "priceCurrency": "MXN",
+                "offers": [
+                    {
+                        "@type": "Offer",
+                        "price": 229,
+                        "priceCurrency": "MXN",
+                        "availability": "http://schema.org/InStock",
+                        "sku": "03344281",
+                        "itemCondition": "http://schema.org/NewCondition",
+                        "priceValidUntil": "2027-06-19T00:00:00Z",
+                        "seller": {
+                            "@type": "Organization",
+                            "name": "Chedraui"
+                        }
+                    }
+                ],
+                "offerCount": 1
+            }
+        ]
+    }
+    """
+
+    name = "chedraui_com_mx"
+    allowed_domains = ["chedraui.com.mx"]
+    user_agent = BROWSER_DEFAULT
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q2961952",
+                "name": "Chedraui",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.chedraui.com.mx/sitemap.xml"]
+    sitemap_rules = [
+        (r"/.*-(\d+)/p$", "parse_sd"),
+    ]


### PR DESCRIPTION
This PR implements a web scraper for Chedraui (Mexico) as requested in issue #116.

The spider uses the site's sitemap to discover product pages and leverages the existing `StructuredDataSpider` to extract Schema.org metadata. 

Key features:
- Inherits from `SitemapSpider` and `StructuredDataSpider`.
- Targets product URLs matching `/.*-(\d+)/p$`.
- Includes Wikidata attribution (Q2961952).

Sample output structured data:
```json
{
    "extras": {
        "@source_uri": "https://www.chedraui.com.mx/avena-bobs-red-mill-organica-estilo-escoces-567g-3344281/p",
        "seller": {
            "@id": "https://www.wikidata.org/wiki/Q2961952",
            "@type": "Organization",
            "name": "Chedraui"
        }
    },
    "image": "https://chedrauimx.vtexassets.com/arquivos/ids/70006182/39978029560_00.jpg?v=639150049591370000",
    "name": "Avena Bob's Red Mill Orgánica Estilo Escocés 567g",
    "offers": [
        {
            "@type": "AggregateOffer",
            "highPrice": 229,
            "lowPrice": 229,
            "offerCount": 1,
            "offers": [
                {
                    "@type": "Offer",
                    "availability": "http://schema.org/InStock",
                    "itemCondition": "http://schema.org/NewCondition",
                    "price": 229,
                    "priceCurrency": "MXN",
                    "priceValidUntil": "2027-06-19T00:00:00Z",
                    "seller": {
                        "@type": "Organization",
                        "name": "Chedraui"
                    },
                    "sku": "03344281"
                }
            ],
            "priceCurrency": "MXN"
        }
    ],
    "ref": "03344281",
    "website": "https://www.chedraui.com.mx/avena-bobs-red-mill-organica-estilo-escoces-567g-3344281/p"
}
```

---
*PR created automatically by Jules for task [16796536560093604930](https://jules.google.com/task/16796536560093604930) started by @CloCkWeRX*