### PR TITLE
Add Picard (France) spider

### DIFF
--- a/products/spiders/picard_fr.py
+++ b/products/spiders/picard_fr.py
@@ -1,0 +1,56 @@
+from products.structured_data_spider import StructuredDataSpider
+from scrapy.spiders import SitemapSpider
+
+
+class PicardFRSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Picard (France).
+    Extracts product data from JSON-LD.
+
+    Sample output:
+    {
+        "extras": {
+            "@source_uri": "https://www.picard.fr/produits/filets-poulet-7-10-pieces-000000000000000545.html",
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q3382454",
+                "name": "Picard Surgelés"
+            }
+        },
+        "name": "Filets de poulet, 5 à 10 pièces",
+        "website": "https://www.picard.fr/produits/filets-poulet-7-10-pieces-000000000000000545.html",
+        "image": "https://www.picard.fr/dw/image/v2/AAHV_PRD/on/demandware.static/-/Sites-catalog-picard/default/dwdd0208dc/produits/000000000000000545_E.jpg?sw=672&sh=392&q=30",
+        "ref": "000000000000000545",
+        "offers": [
+            {
+                "@type": "Offer",
+                "availability": "https://schema.org/InStock",
+                "priceCurrency": "EUR",
+                "priceValidUntil": "2026-06-28",
+                "url": "https://www.picard.fr/produits/filets-poulet-7-10-pieces-000000000000000545.html",
+                "price": "18.99"
+            }
+        ]
+    }
+    """
+
+    name = "picard_fr"
+    allowed_domains = ["picard.fr"]
+    sitemap_urls = ["https://www.picard.fr/sitemap_0.xml"]
+    sitemap_rules = [(r"/produits/.*-([A-Z0-9]+)\.html", "parse_sd")]
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if item.get("ref") == "null" or not item.get("ref"):
+            item["ref"] = self.get_ref(response.url, response)
+
+        yield item
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q3382454",
+                "name": "Picard Surgelés",
+            }
+        }
+    }


### PR DESCRIPTION
I have implemented a new Scrapy spider for the French frozen food retailer Picard (picard.fr). 

### Key Features:
- **Sitemap Integration**: Uses the main sitemap index to discover product pages.
- **Structured Data Extraction**: Leverages `StructuredDataSpider` to extract JSON-LD metadata.
- **Robust Reference Extraction**: Automatically falls back to regex-based extraction from the URL when the site provides a "null" SKU in its structured data.
- **Wikidata Support**: Includes the Wikidata ID `Q3382454` for Picard Surgelés.
- **Naming Consistency**: Verified that the spider class name matches the file name.

### Verification:
I tested the spider with a 2-minute timeout, and it successfully scraped over 100 items with full product details. I have also verified that no temporary files were left in the repository and that the naming conventions align with the project's CI requirements.

Fixes #1

---
*PR created automatically by Jules for task [899965012431808873](https://jules.google.com/task/899965012431808873) started by @CloCkWeRX*