### PR TITLE
Add Marketplace HK spider

### DIFF
--- a/products/spiders/marketplace_hk.py
+++ b/products/spiders/marketplace_hk.py
@@ -1,0 +1,23 @@
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from products.structured_data_spider import StructuredDataSpider
+
+class MarketplaceHKSpider(CrawlSpider, StructuredDataSpider):
+    name = "marketplace_hk"
+    allowed_domains = ["marketplacehk.com"]
+    start_urls = ["https://www.marketplacehk.com/zh-hant"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q6770713",
+                "name": "Market Place",
+            }
+        }
+    }
+
+    rules = (
+        Rule(LinkExtractor(allow=r"/p/.+/i/.+\.html"), callback="parse_sd"),
+        Rule(LinkExtractor(allow=r"/category/")),
+    )


### PR DESCRIPTION
This pull request adds a new Scrapy spider for Market Place Hong Kong (`marketplacehk.com`), which addresses issue #139.

The spider uses `CrawlSpider` combined with `StructuredDataSpider` to extract schema.org product data. It includes the Wikidata ID `Q6770713` for Market Place.

Fix #139

Sample output:
```json
{"extras": {"@source_uri": "https://www.marketplacehk.com/zh-hant/wellcome/p/%E6%96%B0%E7%91%AA%E5%88%A9%E8%8E%8A%E5%9C%92%20%E8%98%87%E7%B6%AD%E7%BF%81%E7%99%BD%E9%85%92%20750ML/i/113664616.html", "seller": {"@type": "Organization", "@id": "https://www.wikidata.org/wiki/Q6770713", "name": "Market Place"}}, "name": "\u65b0\u746a\u5229\u838a\u5712 \u8607\u7dad\u7fc1\u767d\u9152 750ML", "website": "https://www.marketplacehk.com/zh-hant/wellcome/p/%E6%96%B0%E7%91%AA%E5%88%A9%E8%8E%8A%E5%9C%92%20%E8%98%87%E7%B6%AD%E7%BF%81%E7%99%BD%E9%85%92%20750ML/i/113664616.html", "image": "https://img.rtacdn-os.com/20260306/f8163b2d-5637-3778-846c-d287d6fd4405", "ref": "https://www.marketplacehk.com/zh-hant/wellcome/p/%E6%96%B0%E7%91%AA%E5%88%A9%E8%8E%8A%E5%9C%92%20%E8%98%87%E7%B6%AD%E7%BF%81%E7%99%BD%E9%85%92%20750ML/i/113664616.html", "offers": [{"@type": "Offer", "price": "55.00", "priceCurrency": "HKD"}]}
```

---
*PR created automatically by Jules for task [6900925808955524539](https://jules.google.com/task/6900925808955524539) started by @CloCkWeRX*