### PR TITLE
Add Bonpreu Esclat spider

### DIFF
--- a/products/spiders/bonpreuesclat_es.py
+++ b/products/spiders/bonpreuesclat_es.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class BonpreuesclatESSpider(SitemapSpider, StructuredDataSpider):
+    name = "bonpreuesclat_es"
+    allowed_domains = ["compraonline.bonpreuesclat.cat"]
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q11924747",
+                "name": "Grup Bon Preu",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.compraonline.bonpreuesclat.cat/robots.txt"]
+    sitemap_rules = [
+        (r"/products/.*/\d+$", "parse_sd"),
+    ]


### PR DESCRIPTION
Implement a new spider for Bonpreu Esclat (compraonline.bonpreuesclat.cat).
The spider uses the site's XML sitemaps for discovery and extracts schema.org Product data from product pages.
Includes seller metadata with Wikidata ID Q11924747.

Fix #108

Sample output:
```json
{"extras": {"@source_uri": "https://www.compraonline.bonpreuesclat.cat/products/ed-estrella-polar-llibre-anna-kadabra-15/97085", "seller": {"@type": "Organization", "@id": "https://www.wikidata.org/wiki/Q11924747", "name": "Grup Bon Preu"}}, "name": "ED. ESTRELLA POLAR Llibre Anna Kadabra 15", "website": "https://www.compraonline.bonpreuesclat.cat/products/ed-estrella-polar-llibre-anna-kadabra-15/97085", "image": "https://www.compraonline.bonpreuesclat.cat/images-v3/dcbcfd72-cf23-44a2-8e14-8a38edd645a3/b3e05a95-cdc5-4bd1-be3b-ab503244aa9b/500x500.jpg", "ref": "97085", "offers": [{"@type": "Offer", "price": "11.95", "priceCurrency": "EUR", "itemCondition": "https://schema.org/NewCondition", "availability": "https://schema.org/InStock"}]}
```

---
*PR created automatically by Jules for task [5134870755304100239](https://jules.google.com/task/5134870755304100239) started by @CloCkWeRX*