### PR TITLE
Add Denner (Switzerland) spider

### DIFF
--- a/products/spiders/denner_ch.py
+++ b/products/spiders/denner_ch.py
@@ -1,0 +1,56 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import BROWSER_DEFAULT
+
+
+class DennerCHSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Denner (Switzerland).
+    Wikidata: Q379911
+
+    Sample output structured data:
+    {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "brand": {
+            "@type": "Brand",
+            "name": "Denner"
+        },
+        "sku": "463348",
+        "mpn": "463348",
+        "name": "Winston Hundefutter Kalb mit frischem Pansen",
+        "image": [
+            "https://denner.imgix.net/assets/c2b834da-919f-4352-af6d-ee657caa825b/web/463348_24_01_15.png"
+        ],
+        "description": "ohne Zucker- und Getreidezusatz, 175 g",
+        "offers": [
+            {
+                "@type": "Offer",
+                "url": "https://www.denner.ch/de/aktionen/~p463348?locale=de&context=default",
+                "availability": "https://schema.org/InStoreOnly",
+                "price": 1.4,
+                "priceCurrency": "CHF"
+            }
+        ]
+    }
+    """
+
+    name = "denner_ch"
+    allowed_domains = ["denner.ch"]
+    user_agent = BROWSER_DEFAULT
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q379911",
+                "name": "Denner",
+            }
+        }
+    }
+
+    sitemap_urls = ["https://www.denner.ch/sitemap.xml"]
+    sitemap_rules = [
+        (r"~p(\d+)(?:\?.*)?$", "parse"),
+    ]


### PR DESCRIPTION
Fix #125

Implemented a new web scraper for Denner (Switzerland) at `denner.ch`. The spider uses Scrapy's `SitemapSpider` to discover products via `https://www.denner.ch/sitemap.xml` and inherits from `StructuredDataSpider` to extract `schema.org/Product` data from JSON-LD.

Sample structured data output:
```json
{
  "extras": {
    "@source_uri": "https://www.denner.ch/it/azioni/snack-per-cani-salame-succulento-con-manzo-winston~p1030338",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q379911",
      "@type": "Organization",
      "name": "Denner"
    }
  },
  "name": "Snack per cani Salame succulento con manzo Winston",
  "website": "https://www.denner.ch/it/azioni/snack-per-cani-salame-succulento-con-manzo-winston~p1030338",
  "image": "https://denner.imgix.net/assets/373ded46-7e6f-4a1e-b64f-6f6ed92398b2/web/463356_24_01_15.png",
  "ref": "1030338",
  "offers": [
    {
      "@type": "Offer",
      "url": "https://www.denner.ch/it/azioni/~p1030338?locale=it&context=promotion",
      "availability": "https://schema.org/InStoreOnly",
      "price": 2.2,
      "priceCurrency": "CHF"
    }
  ]
}
```

---
*PR created automatically by Jules for task [768753537200904706](https://jules.google.com/task/768753537200904706) started by @CloCkWeRX*