### PR TITLE
Add Fakta (EU) spider for issue #132

### DIFF
--- a/products/spiders/fakta_eu.py
+++ b/products/spiders/fakta_eu.py
@@ -1,0 +1,87 @@
+import re
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+from products.items import Product
+from scrapy.http import Response
+
+
+class FaktaEUSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Fakta (EU).
+    Wikidata: Q1394332
+
+    Sample output structured data:
+    {
+        "name": "Krydderihaven Ras el hanout 150 g",
+        "website": "https://www.fakta.eu/pi/Krydderihaven-Ras-el-hanout-150-g_22338183_162157.aspx",
+        "image": "https://www.fakta.eu/Services/ImageHandler.ashx?imgId=2539633&sizeId=0&RevisionNo=0_0",
+        "ref": "5712426000049",
+        "sku": "5712426000049",
+        "offers": [
+            {
+                "@type": "Offer",
+                "url": "https://www.fakta.eu/pi/Krydderihaven-Ras-el-hanout-150-g_22338183_162157.aspx",
+                "priceCurrency": "DKK",
+                "price": 24.99,
+                "availability": "https://schema.org/InStock"
+            }
+        ],
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q1394332",
+                "name": "Fakta"
+            }
+        }
+    }
+    """
+
+    name = "fakta_eu"
+    allowed_domains = ["fakta.eu"]
+    sitemap_urls = ["https://www.fakta.eu/googlesitemap.ashx"]
+    sitemap_rules = [
+        (r"/pi/.*_(\d+)_(\d+)\.aspx$", "parse_sd"),
+    ]
+
+    json_parser = "chompjs"
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q1394332",
+                "name": "Fakta",
+            }
+        }
+    }
+
+    def post_process_item(self, item: Product, response: Response, ld_data: dict, **kwargs):
+        # Handle the dynamic price variable 'tagPrice'
+        for offer in item.get("offers", []):
+            if offer.get("price") == "tagPrice":
+                # Try to extract tagPrice from the page source
+                # Example: var tagPrice = Number(14,9899938000.replace(',','.')).toFixed(2);
+                match = re.search(r"var tagPrice = Number\(([^)]+)\)", response.text)
+                if match:
+                    price_expr = match.group(1)
+                    # Split by comma to handle the comma operator in JS
+                    parts = price_expr.split(",")
+                    if len(parts) > 1:
+                        # Find the first part that looks like it has a numeric value
+                        # In "14,9899938000.replace(',','.')", parts are ["14", "9899938000.replace('", "'", "'.')"]
+                        # This is tricky because .replace(',','.') also contains commas.
+                        # Re-join parts that belong to the replace call.
+                        # Actually, just take the first part and the start of the second part.
+                        price_str = parts[0] + "." + re.sub(r"[^\d]", "", parts[1])
+                    else:
+                        price_str = re.sub(r"[^\d.]", "", price_expr)
+
+                    try:
+                        offer["price"] = round(float(price_str), 2)
+                    except ValueError:
+                        pass
+
+        if not item.get("ref") and item.get("sku"):
+            item["ref"] = item["sku"]
+
+        yield item


### PR DESCRIPTION
I have implemented a new Scrapy spider for Fakta (fakta.eu) as requested in issue #132. The spider uses the site's XML sitemaps for product discovery and extracts schema.org structured data from the product pages.

Key features:
- **Base Classes**: Inherits from `SitemapSpider` and `StructuredDataSpider`.
- **Wikidata**: Included Fakta's Wikidata ID (`Q1394332`).
- **Dynamic Price Handling**: The site uses a non-standard JSON-LD structure where the price is a JavaScript variable (`tagPrice`). I implemented custom extraction logic in `post_process_item` to parse this variable from the page source and update the product item with the correct numeric price.
- **Naming Consistency**: Verified that the class name `FaktaEUSpider` and file name `fakta_eu.py` comply with the project's standards.

Sample output is included in the commit message and the spider's docstring.

Fix #132

---
*PR created automatically by Jules for task [17898376036926501222](https://jules.google.com/task/17898376036926501222) started by @CloCkWeRX*