### PR TITLE
Add Gelson's Markets (US) spider

### DIFF
--- a/products/spiders/gelsons_us.py
+++ b/products/spiders/gelsons_us.py
@@ -1,0 +1,35 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class GelsonsUSSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Gelson's Markets (United States) spider.
+    Wikidata: Q16993993
+    """
+
+    name = "gelsons_us"
+    allowed_domains = ["gelsons.com"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q16993993",
+                "name": "Gelson's Markets",
+            }
+        }
+    }
+
+    custom_settings = {
+        "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0",
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    sitemap_urls = [
+        "https://shop.gelsons.com/sitemaps/storefront_pro/shop_gelsons_com/products/sitemap0.xml",
+    ]
+    sitemap_rules = [
+        (r"/products/(\d+)-", "parse_sd"),
+    ]


### PR DESCRIPTION
This PR adds a web scraper for Gelson's Markets (United States).
It uses the Instacart-powered storefront at shop.gelsons.com to extract schema.org structured data.

Sample output:
```json
{
  "extras": {
    "@source_uri": "https://shop.gelsons.com/store/gelsons/products/322321-mont-pellier-california-viognier-750-ml",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q16993993",
      "@type": "Organization",
      "name": "Gelson's Markets"
    }
  },
  "image": "https://d2lnr5mha7bycj.cloudfront.net/product-image/file/large_215e52bc-2d68-4d31-a2fc-06357f865cf3.jpg",
  "name": "Mont Pellier California Viognier",
  "offers": [
    {
      "@type": "Offer",
      "availability": "https://schema.org/InStock",
      "itemCondition": "https://schema.org/NewCondition",
      "price": "8.99",
      "priceCurrency": "USD",
      "url": "https://shop.gelsons.com/store/gelsons/products/322321-mont-pellier-california-viognier-750-ml"
    }
  ],
  "ref": "322321",
  "website": "https://shop.gelsons.com/store/gelsons/products/322321-mont-pellier-california-viognier-750-ml"
}
```

Fix #137

---
*PR created automatically by Jules for task [18266400742577482611](https://jules.google.com/task/18266400742577482611) started by @CloCkWeRX*