### PR TITLE
Add Rosauers US spider

### DIFF
--- a/products/spiders/rosauers_us.py
+++ b/products/spiders/rosauers_us.py
@@ -1,0 +1,63 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class RosauersUSSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Rosauers (US) spider.
+    Wikidata: Q7367458
+
+    Sample output structured data:
+    {
+        "name": "Rosauers From-Scratch Bakery Muffins",
+        "website": "https://shop.rosauers.com/store/rosauers-supermarkets/products/26558163-b2g1-raspberry-muffins-64-oz",
+        "image": "https://d1s8987jlndkbs.cloudfront.net/assets/missing-item-4bbe82b8555e4d1c12626fd482cb2409713e8e30835645ff3650ef66a725d03c.png",
+        "ref": "26558163",
+        "sku": "26558163",
+        "offers": [
+            {
+                "@type": "Offer",
+                "price": "6.99",
+                "priceCurrency": "USD",
+                "url": "https://shop.rosauers.com/store/rosauers-supermarkets/products/26558163-b2g1-raspberry-muffins-64-oz",
+                "itemCondition": "https://schema.org/NewCondition",
+                "availability": "https://schema.org/InStock"
+            }
+        ],
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q7367458",
+                "name": "Rosauers"
+            }
+        }
+    }
+    """
+
+    name = "rosauers_us"
+    allowed_domains = ["rosauers.com"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q7367458",
+                "name": "Rosauers",
+            }
+        }
+    }
+
+    custom_settings = {
+        "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0",
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    sitemap_urls = [
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap0.xml",
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap1.xml",
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap2.xml",
+    ]
+    sitemap_rules = [
+        (r"/products/(\d+)-", "parse_sd"),
+    ]


### PR DESCRIPTION
Implemented a new web scraper for Rosauers (US) using SitemapSpider and StructuredDataSpider.
Fix #163

Sample output structured data:
```json
{
    "extras": {
        "@source_uri": "https://shop.rosauers.com/store/rosauers-supermarkets/products/2661193-organic-blueberries-6-oz",
        "seller": {
            "@id": "https://www.wikidata.org/wiki/Q7367458",
            "@type": "Organization",
            "name": "Rosauers"
        }
    },
    "image": "https://d2lnr5mha7bycj.cloudfront.net/product-image/file/large_b764481a-afd6-43fa-af34-064bda4d955d.jpg",
    "name": "Organic Blueberries",
    "offers": [
        {
            "@type": "Offer",
            "availability": "https://schema.org/InStock",
            "itemCondition": "https://schema.org/NewCondition",
            "price": "4.99",
            "priceCurrency": "USD",
            "url": "https://shop.rosauers.com/store/rosauers-supermarkets/products/2661193-organic-blueberries-6-oz"
        }
    ],
    "ref": "2661193",
    "website": "https://shop.rosauers.com/store/rosauers-supermarkets/products/2661193-organic-blueberries-6-oz"
}
```

---
*PR created automatically by Jules for task [11370466720159819090](https://jules.google.com/task/11370466720159819090) started by @CloCkWeRX*