### PR TITLE
Add Rosauers (US) spider

### DIFF
--- a/products/spiders/rosauers_us.py
+++ b/products/spiders/rosauers_us.py
@@ -1,0 +1,37 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class RosauersUSSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Rosauers Supermarkets (United States) spider.
+    Wikidata: Q7367458
+    """
+
+    name = "rosauers_us"
+    allowed_domains = ["rosauers.com"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q7367458",
+                "name": "Rosauers Supermarkets",
+            }
+        }
+    }
+
+    custom_settings = {
+        "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0",
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    sitemap_urls = [
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap0.xml",
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap1.xml",
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap2.xml",
+    ]
+    sitemap_rules = [
+        (r"/products/(\d+)-", "parse_sd"),
+    ]


### PR DESCRIPTION
Fix #163

Implemented a web scraper for Rosauers Supermarkets (US) using `SitemapSpider` and `StructuredDataSpider`. The spider targets the Instacart-hosted storefront at `shop.rosauers.com` and extracts product data from schema.org JSON-LD metadata.

Sample structured data:
```json
{
  "extras": {
    "@source_uri": "https://shop.rosauers.com/store/rosauers-supermarkets/products/2661193-organic-blueberries-6-oz",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q7367458",
      "@type": "Organization",
      "name": "Rosauers Supermarkets"
    }
  },
  "image": "https://d2lnr5mha7bycj.cloudfront.net/product-image/file/large_b764481a-afd6-43fa-af34-064bda4d955d.jpg",
  "name": "Organic Blueberries",
  "offers": [
    {
      "@type": "Offer",
      "availability": "https://schema.org/InStock",
      "itemCondition": "https://schema.org/NewCondition",
      "price": "4.99",
      "priceCurrency": "USD",
      "url": "https://shop.rosauers.com/store/rosauers-supermarkets/products/2661193-organic-blueberries-6-oz"
    }
  ],
  "ref": "2661193",
  "website": "https://shop.rosauers.com/store/rosauers-supermarkets/products/2661193-organic-blueberries-6-oz"
}
```

---
*PR created automatically by Jules for task [13077270464651475671](https://jules.google.com/task/13077270464651475671) started by @CloCkWeRX*