### PR TITLE
Add Rosauers Supermarkets (US) spider

### DIFF
--- a/products/spiders/rosauers_us.py
+++ b/products/spiders/rosauers_us.py
@@ -1,0 +1,38 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class RosauersUSSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Rosauers Supermarkets (United States) spider.
+    Wikidata: Q7367458
+    """
+
+    name = "rosauers_us"
+    allowed_domains = ["rosauers.com"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q7367458",
+                "name": "Rosauers Supermarkets",
+            }
+        }
+    }
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    sitemap_urls = [
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap0.xml",
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap1.xml",
+        "https://shop.rosauers.com/sitemaps/storefront_pro/shop_rosauers_com/products/sitemap2.xml",
+    ]
+    sitemap_rules = [
+        (r"/products/(\d+)-", "parse_sd"),
+    ]


### PR DESCRIPTION
Implemented a Scrapy spider for Rosauers Supermarkets using `SitemapSpider` and `StructuredDataSpider`.

### Changes:
- Added `products/spiders/rosauers_us.py`.
- Targeted product sitemaps found in `robots.txt`.
- Included Wikidata ID `Q7367458`.
- Configured realistic User-Agent to bypass potential blocks.

### Sample Structured Data:
```json
{"extras": {"@source_uri": "https://shop.rosauers.com/store/rosauers-supermarkets/products/26490718-merchant-s-craft-diet-cola-12-00-fl-oz", "seller": {"@type": "Organization", "@id": "https://www.wikidata.org/wiki/Q7367458", "name": "Rosauers Supermarkets"}}, "name": "Merchant's Craft Diet Cola", "website": "https://shop.rosauers.com/store/rosauers-supermarkets/products/26490718-merchant-s-craft-diet-cola-12-00-fl-oz", "image": "https://d1s8987jlndkbs.cloudfront.net/assets/missing-item-4bbe82b8555e4d1c12626fd482cb2409713e8e30835645ff3650ef66a725d03c.png", "ref": "26490718", "offers": [{"@type": "Offer", "price": "6.29", "priceCurrency": "USD", "url": "https://shop.rosauers.com/store/rosauers-supermarkets/products/26490718-merchant-s-craft-diet-cola-12-00-fl-oz", "itemCondition": "https://schema.org/NewCondition", "availability": "https://schema.org/InStock"}]}
```

Fix #163

---
*PR created automatically by Jules for task [12338312153117400989](https://jules.google.com/task/12338312153117400989) started by @CloCkWeRX*