### PR TITLE
Add Colruyt (Belgium) spider

### DIFF
--- a/products/spiders/colruyt_be.py
+++ b/products/spiders/colruyt_be.py
@@ -1,0 +1,64 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class ColruytBESpider(SitemapSpider, StructuredDataSpider):
+    """
+    Colruyt (Belgium) spider.
+    Fixes #117.
+    Wikidata: Q2363991
+    Parent: Colruyt Group (Q1111963)
+
+    Sample output:
+    {
+        "name": "Bio graines de courge",
+        "website": "https://www.colruyt.be/fr/produits/22932",
+        "image": "https://static.colruytgroup.com/images/500x500/std.lang.all/07/70/asset-3990770.jpg",
+        "ref": "22932",
+        "brand": "Econoce",
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q2363991",
+                "name": "Colruyt",
+                "parentOrganization": {
+                    "@type": "Organization",
+                    "@id": "https://www.wikidata.org/wiki/Q1111963",
+                    "name": "Colruyt Group"
+                }
+            }
+        }
+    }
+    """
+
+    name = "colruyt_be"
+    allowed_domains = ["colruyt.be"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q2363991",
+                "name": "Colruyt",
+                "parentOrganization": {
+                    "@type": "Organization",
+                    "@id": "https://www.wikidata.org/wiki/Q1111963",
+                    "name": "Colruyt Group",
+                },
+            }
+        }
+    }
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+    }
+
+    sitemap_urls = [
+        "https://www.colruyt.be/nl/sitemap.products.xml",
+        "https://www.colruyt.be/fr/sitemap.products.xml",
+    ]
+    sitemap_rules = [
+        (r"/(?:produits|producten)/(\d+)$", "parse_sd"),
+    ]


### PR DESCRIPTION
Implemented a new spider for Colruyt (Belgium) in `products/spiders/colruyt_be.py`. The spider uses `SitemapSpider` to discover product URLs from the Dutch and French sitemaps and `StructuredDataSpider` to extract Schema.org metadata from the pages. Added Wikidata IDs for Colruyt (Q2363991) and Colruyt Group (Q1111963). Verified that the spider correctly handles the site's AntiBot protection by using a realistic User-Agent. Tested with a 2-minute crawl and verified the output. Fixes #117.

---
*PR created automatically by Jules for task [1171168668593747172](https://jules.google.com/task/1171168668593747172) started by @CloCkWeRX*