### PR TITLE
Add Auchan PT spider

### DIFF
--- a/products/spiders/auchan_pt.py
+++ b/products/spiders/auchan_pt.py
@@ -1,0 +1,27 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class AuchanPTSpider(SitemapSpider, StructuredDataSpider):
+    name = "auchan_pt"
+    allowed_domains = ["auchan.pt"]
+    user_agent = FIREFOX_LATEST
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q105857776",
+                "name": "Auchan",
+            }
+        }
+    }
+
+    sitemap_urls = [
+        "https://www.auchan.pt/sitemap_index.xml",
+    ]
+    sitemap_rules = [
+        (r"/(\d+)\.html$", "parse"),
+    ]


### PR DESCRIPTION
Implemented a new spider for Auchan (Portugal) using `SitemapSpider` and `StructuredDataSpider`. The site exposes product data via JSON-LD.

Fix #245

Sample output structured data:
```json
{
  "extras": {
    "@source_uri": "https://www.auchan.pt/pt/saude-e-bem-estar/cuidados-de-cabelo/amaciadores/condicionador-kativa-argan-olive-peptides-90ml/4044976.html",
    "seller": {
      "@type": "Organization",
      "@id": "https://www.wikidata.org/wiki/Q105857776",
      "name": "Auchan"
    }
  },
  "name": "CONDICIONADOR KATIVA ARGAN OLIVE PEPTIDES 90ML",
  "website": "https://www.auchan.pt/pt/saude-e-bem-estar/cuidados-de-cabelo/amaciadores/condicionador-kativa-argan-olive-peptides-90ml/4044976.html",
  "image": "https://www.auchan.pt/on/demandware.static/Sites-AuchanPT-Site/-/default/dw30968af6/images/fallback_product_image.jpeg",
  "ref": "4044976",
  "offers": [
    {
      "url": {},
      "@type": "Offer",
      "priceCurrency": "EUR",
      "price": "2.55",
      "availability": "http://schema.org/InStock"
    }
  ]
}
```

---
*PR created automatically by Jules for task [9665528075432152528](https://jules.google.com/task/9665528075432152528) started by @CloCkWeRX*