### PR TITLE
Add metro_ca spider

### DIFF
--- a/products/spiders/metro_ca.py
+++ b/products/spiders/metro_ca.py
@@ -1,0 +1,93 @@
+from scrapy import Request
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class MetroCASpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Metro (Canada).
+    Extracts product data from Microdata (Schema.org Product).
+    Uses Playwright to bypass Cloudflare.
+    Fix #286.
+
+    Sample output:
+    {
+        "name": "Boisson gazeuse à saveur d'orange",
+        "website": "https://www.metro.ca/epicerie-en-ligne/allees/boissons/boissons-gazeuses/aromatisees-aux-fruits-et-soda-mousse/boisson-gazeuse-a-saveur-d-orange/p/056000006832",
+        "ref": "056000006832",
+        "offers": [
+            {
+                "@type": "Offer",
+                "price": "2.49",
+                "priceCurrency": "CAD"
+            }
+        ],
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q1925345",
+                "name": "Metro",
+                "parentOrganization": {
+                    "@type": "Organization",
+                    "@id": "https://www.wikidata.org/wiki/Q1145669",
+                    "name": "Metro Inc."
+                }
+            }
+        }
+    }
+    """
+
+    name = "metro_ca"
+    allowed_domains = ["metro.ca"]
+    sitemap_urls = ["https://www.metro.ca/sitemap.xml"]
+    sitemap_rules = [(r"/p/(\d+)$", "parse_sd")]
+
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "DOWNLOAD_HANDLERS": {
+            "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+            "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+        },
+        "PLAYWRIGHT_BROWSER_TYPE": "firefox",
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 60 * 1000,
+        "PLAYWRIGHT_LAUNCH_OPTIONS": {
+            "headless": True,
+        },
+        "ROBOTSTXT_OBEY": False,
+        "USER_AGENT": FIREFOX_LATEST,
+        "DEFAULT_REQUEST_HEADERS": {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Accept-Language": "en-CA,en-US;q=0.9,en;q=0.8,fr-CA;q=0.7,fr;q=0.6",
+        },
+    }
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q1925345",
+                "name": "Metro",
+                "parentOrganization": {
+                    "@type": "Organization",
+                    "@id": "https://www.wikidata.org/wiki/Q1145669",
+                    "name": "Metro Inc.",
+                },
+            }
+        }
+    }
+
+    def start_requests(self):
+        for url in self.sitemap_urls:
+            yield Request(url, self._parse_sitemap, meta={"playwright": True})
+
+    def _parse_sitemap(self, response):
+        """
+        Ensure subsequent requests from the sitemap also use Playwright.
+        """
+        for request_or_item in super()._parse_sitemap(response):
+            if isinstance(request_or_item, Request):
+                request_or_item.meta["playwright"] = True
+                yield request_or_item
+            else:
+                yield request_or_item


### PR DESCRIPTION
This PR adds a new spider for Metro Canada (`metro_ca`).

The spider:
- Uses `SitemapSpider` for product discovery via `https://www.metro.ca/sitemap.xml`.
- Uses `StructuredDataSpider` to extract Schema.org Product data (Microdata).
- Configures `scrapy-playwright` with Firefox to bypass Cloudflare protection.
- Includes Wikidata IDs for Metro (`Q1925345`) and Metro Inc. (`Q1145669`).

Sample output:
```json
{
    "extras": {
        "@source_uri": "https://www.metro.ca/en/online-grocery/aisles/baby/food-formula/food/organic-gluten-free-apples-spinach-kiwi-broccoli-and-quinoa-puree-pouch-for-babies-6-months/p/858860001121",
        "seller": {
            "@type": "Organization",
            "@id": "https://www.wikidata.org/wiki/Q1925345",
            "name": "Metro",
            "parentOrganization": {
                "@type": "Organization",
                "@id": "https://www.wikidata.org/wiki/Q1145669",
                "name": "Metro Inc."
            }
        }
    },
    "name": "Organic Gluten Free Apples, Spinach, Kiwi, Broccoli and Quinoa Purée Pouch for Babies 6+ Months",
    "website": "https://www.metro.ca/en/online-grocery/aisles/baby/food-formula/food/organic-gluten-free-apples-spinach-kiwi-broccoli-and-quinoa-puree-pouch-for-babies-6-months/p/858860001121",
    "image": "https://product-images.metro.ca/images/h37/hb0/16353619673118.jpg",
    "ref": "858860001121",
    "offers": [
        {
            "@type": "Offer",
            "price": "2.79",
            "priceCurrency": "CAD"
        }
    ]
}
```

---
*PR created automatically by Jules for task [17687044683623790853](https://jules.google.com/task/17687044683623790853) started by @CloCkWeRX*