### PR TITLE
Add Lider (Chile) spider

### DIFF
--- a/products/spiders/lider_cl.py
+++ b/products/spiders/lider_cl.py
@@ -1,0 +1,22 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class LiderCLSpider(SitemapSpider, StructuredDataSpider):
+    name = "lider_cl"
+    allowed_domains = ["lider.cl"]
+    sitemap_urls = ["https://www.lider.cl/siteindex.xml"]
+    sitemap_rules = [
+        (r"/ip/.*/(\d+)$", "parse_sd"),
+    ]
+
+    item_attributes = {
+        "brand": "Líder",
+        "brand_wikidata": "Q6711261",
+    }
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+    }


### PR DESCRIPTION
Implemented a new Scrapy spider for Lider (Chile) in `products/spiders/lider_cl.py`. The spider inherits from `SitemapSpider` and `StructuredDataSpider` to efficiently discover and parse product pages using XML sitemaps and JSON-LD structured data. It includes the Wikidata ID for Walmart Chile (Q6711261) and correctly handles product URL patterns. Verification was performed by running the spider with a limited item count and confirming the extracted data matches expectations.

---
*PR created automatically by Jules for task [7414314523706274689](https://jules.google.com/task/7414314523706274689) started by @CloCkWeRX*