### PR TITLE
Add Sprouts Farmers Market (US) spider

### DIFF
--- a/products/spiders/sprouts_us.py
+++ b/products/spiders/sprouts_us.py
@@ -1,0 +1,27 @@
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+from scrapy.spiders import SitemapSpider
+
+
+class SproutsUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "sprouts_us"
+    allowed_domains = ["shop.sprouts.com"]
+    sitemap_urls = [
+        "https://shop.sprouts.com/sitemaps/storefront_pro/shop_sprouts_com/sitemap.xml"
+    ]
+    sitemap_rules = [(r"/products/(\d+)-", "parse_sd")]
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q7581369",
+                "name": "Sprouts Farmers Market",
+            }
+        }
+    }


### PR DESCRIPTION
I have implemented a new Scrapy spider for Sprouts Farmers Market (US) to address issue #275. 

Key changes:
- Created `products/spiders/sprouts_us.py`.
- Used `SitemapSpider` for efficient product discovery via `https://shop.sprouts.com/sitemaps/storefront_pro/shop_sprouts_com/sitemap.xml`.
- Integrated `StructuredDataSpider` for automatic extraction of Schema.org `Product` data.
- Added Wikidata ID `Q7581369` for Sprouts Farmers Market as a spider-level attribute.
- Configured a realistic User-Agent (`FIREFOX_LATEST`) and set `ROBOTSTXT_OBEY = False` to ensure reliable crawling.

The spider has been verified with a limited crawl and successfully extracts product name, price, currency, availability, image, and unique reference (SKU).

---
*PR created automatically by Jules for task [4614552055789691151](https://jules.google.com/task/4614552055789691151) started by @CloCkWeRX*