### PR TITLE
Add Erewhon Market (US) spider

### DIFF
--- a/products/spiders/erewhon_us.py
+++ b/products/spiders/erewhon_us.py
@@ -1,0 +1,17 @@
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+
+
+class ErewhonUSSpider(SitemapSpider, StructuredDataSpider):
+    name = "erewhon_us"
+    allowed_domains = ["ship.erewhon.com"]
+    sitemap_urls = ["https://ship.erewhon.com/sitemap.xml"]
+    sitemap_rules = [(r"/products/", "parse_sd")]
+
+    item_attributes = {
+        "brand": "Erewhon",
+        "brand_wikidata": "Q105628552",
+        "extras": {
+            "seller": "Erewhon",
+        },
+    }


### PR DESCRIPTION
This PR adds a new spider for Erewhon Market (US).

### Changes:
- Added `products/spiders/erewhon_us.py`.
- Includes Wikidata ID `Q105628552`.
- Uses `SitemapSpider` for efficient product discovery via `ship.erewhon.com`.

### Sample Output:
```json
{
  "brand": "Erewhon",
  "brand_wikidata": "Q105628552",
  "extras": {
    "@source_uri": "https://ship.erewhon.com/products/anti-bacterial-hand-sanitizer-spray",
    "seller": "Erewhon"
  },
  "image": "https://ship.erewhon.com/cdn/shop/files/HANDSANITIZERANTIBACTERIALSPRAY2OZ_ECOMM_1.png?v=1704766906&width=1920",
  "name": "Antibacterial Hand Sanitizer Spray",
  "offers": [
    {
      "@id": "/products/anti-bacterial-hand-sanitizer-spray?variant=40717021970570#offer",
      "@type": "Offer",
      "availability": "http://schema.org/InStock",
      "price": "9.00",
      "priceCurrency": "USD",
      "url": "https://ship.erewhon.com/products/anti-bacterial-hand-sanitizer-spray?variant=40717021970570"
    }
  ],
  "ref": "602581685425",
  "website": "https://ship.erewhon.com/products/anti-bacterial-hand-sanitizer-spray"
}
```

Fix #296

---
*PR created automatically by Jules for task [11659126960254199141](https://jules.google.com/task/11659126960254199141) started by @CloCkWeRX*