### PR TITLE
Add lottemartzetta_kr spider

### DIFF
--- a/products/spiders/lottemartzetta_kr.py
+++ b/products/spiders/lottemartzetta_kr.py
@@ -1,0 +1,43 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class LottemartzettaKRSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Lotte Mart Zetta (South Korea) spider.
+    Fixes #274.
+    Wikidata: Q326715 (Lotte Mart)
+    """
+
+    name = "lottemartzetta_kr"
+    allowed_domains = ["lottemartzetta.com"]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q326715",
+                "name": "Lotte Mart",
+            }
+        }
+    }
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    sitemap_urls = [
+        "https://lottemartzetta.com/sitemaps/sitemap_index.xml",
+    ]
+    sitemap_rules = [
+        (r"/products/(OS[A-Z0-9]+)/details", "parse_sd"),
+    ]
+
+    def _parse_sitemap(self, response):
+        for request in super()._parse_sitemap(response):
+            if "products" in request.url:
+                request.meta["playwright"] = True
+            yield request


### PR DESCRIPTION
Implement a new spider for Lotte Mart Zetta (South Korea) to address issue #274.
The spider uses `SitemapSpider` for product discovery and `StructuredDataSpider` for extraction of JSON-LD data.
Since the site uses AWS WAF/CloudFront challenges, `scrapy-playwright` with Firefox is used for product pages.

Wikidata ID: Q326715 (Lotte Mart)

Sample output:
```json
{
    "name": "스파이더락 스텐딩 스텐 코너 3단 선반",
    "website": "https://lottemartzetta.com/products/OS8809199290962/details",
    "image": "https://lottemartzetta.com/images-v3/932dcbc7-fca8-4d43-bcde-f73d1ce3cc7d/105e1f04-57c1-49b3-ad14-e73998212822/500x500.jpg",
    "ref": "OS8809199290962",
    "offers": [
        {
            "@type": "Offer",
            "price": "32900",
            "priceCurrency": "KRW",
            "itemCondition": "https://schema.org/NewCondition",
            "availability": "https://schema.org/InStock"
        }
    ],
    "extras": {
        "seller": {
            "@type": "Organization",
            "@id": "https://www.wikidata.org/wiki/Q326715",
            "name": "Lotte Mart"
        }
    }
}
```

Fix #274

---
*PR created automatically by Jules for task [7427267166685621139](https://jules.google.com/task/7427267166685621139) started by @CloCkWeRX*