### PR TITLE
Add Univerexport (Serbia) spider

### DIFF
--- a/products/spiders/univerexport_rs.py
+++ b/products/spiders/univerexport_rs.py
@@ -1,0 +1,81 @@
+import re
+from scrapy.spiders import SitemapSpider
+from products.items import Product
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+class UniverexportRSSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Univerexport (Serbia) spider.
+    Fixes #255.
+    Wikidata: Q12747294
+
+    Sample output:
+    {
+        "name": "JABUKA AJDARED",
+        "website": "https://elakolije.rs/1334599/proizvod/jabuka-ajdared",
+        "image": "https://elakolije.rs/slike_pro/pro_v_1334599.jpg",
+        "ref": "1334599",
+        "located_in": "SRBIJA",
+        "price": 149.99,
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q12747294",
+                "name": "Univerexport"
+            }
+        }
+    }
+    """
+
+    name = "univerexport_rs"
+    allowed_domains = ["elakolije.rs"]
+    sitemap_urls = ["https://elakolije.rs/out/sitemap.xml"]
+    sitemap_rules = [(r"/(\d+)/proizvod/", "parse_product")]
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q12747294",
+                "name": "Univerexport",
+            }
+        }
+    }
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+    }
+
+    def parse_product(self, response):
+        product = Product()
+        product["website"] = response.url
+
+        name = response.css("#proizvod_naslov::text").get()
+        if name:
+            product["name"] = name.strip()
+
+        image = response.css("#proizvod_okvir_slika img::attr(src)").get()
+        if image:
+            product["image"] = response.urljoin(image)
+
+        ref_match = re.search(r"/(\d+)/proizvod/", response.url)
+        if ref_match:
+            product["ref"] = ref_match.group(1)
+
+        price = response.css("input.price::attr(value)").get()
+        if price:
+            try:
+                product["price"] = float(price)
+            except ValueError:
+                pass
+
+        brand = response.xpath("//th[contains(text(), 'Stavlja u promet')]/following-sibling::td/text()").get()
+        if brand:
+            product["brand"] = brand.replace("PROIZVODjAC:", "").strip()
+
+        origin = response.xpath("//th[contains(text(), 'Zemlja porekla')]/following-sibling::td/text()").get()
+        if origin:
+            product["located_in"] = origin.strip()
+
+        yield from self.post_process_item(product, response, {})


### PR DESCRIPTION
Fix #255

Implemented a new Scrapy spider for Univerexport (Serbia) available at `elakolije.rs`. 
The spider uses the sitemap index to discover products and extracts name, price, image, reference, brand, and country of origin.
It also includes the Wikidata ID for the retailer.

Sample output:
```json
{
  "extras": {
    "seller": {
      "@type": "Organization",
      "@id": "https://www.wikidata.org/wiki/Q12747294",
      "name": "Univerexport"
    }
  },
  "website": "https://elakolije.rs/1345324/proizvod/krekeri-multigrain-nordic-tak-125g",
  "name": "KREKERI MULTIGRAIN NORDIC TAK 125G",
  "image": "https://elakolije.rs/slike_pro/pro_v_1345324.jpg",
  "ref": "1345324",
  "price": 72.99,
  "brand": "Jaffa doo Crvenka",
  "located_in": "Srbija"
}
```

---
*PR created automatically by Jules for task [1573873137779771348](https://jules.google.com/task/1573873137779771348) started by @CloCkWeRX*