### PR TITLE
Add Covabra (Brazil) spider

### DIFF
--- a/products/spiders/covabra_br.py
+++ b/products/spiders/covabra_br.py
@@ -1,0 +1,36 @@
+from scrapy.http import Response
+from scrapy.spiders import SitemapSpider
+
+from products.items import Product
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import BROWSER_DEFAULT
+
+
+class CovabraBRSpider(SitemapSpider, StructuredDataSpider):
+    name = "covabra_br"
+    allowed_domains = ["covabra.com.br"]
+    user_agent = BROWSER_DEFAULT
+
+    sitemap_urls = ["https://www.covabra.com.br/sitemap.xml"]
+    sitemap_rules = [
+        (r"/p$", "parse_sd"),
+    ]
+
+    item_attributes = {
+        "brand_wikidata": "Q131063998",
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "name": "Covabra",
+                "@id": "https://www.wikidata.org/wiki/Q131063998",
+            }
+        },
+    }
+
+    def post_process_item(self, item: Product, response: Response, ld_data: dict):
+        if not item.get("ref"):
+            # Try to get ref from sku or mpn if missing
+            item["ref"] = item.get("sku") or item.get("mpn")
+
+        if item.get("name"):
+            yield item


### PR DESCRIPTION
This PR adds a new spider for Covabra (Brazil) supermercados (covabra.com.br).
It uses the `SitemapSpider` and `StructuredDataSpider` to extract product information from the site's JSON-LD.
Wikidata information (Q131063998) is included.

Fix #321

Sample output:
```json
[
{"extras": {"@source_uri": "https://www.covabra.com.br/not-milkinho-chocolate-leite-vegetal-200ml/p", "seller": {"@type": "Organization", "name": "Covabra", "@id": "https://www.wikidata.org/wiki/Q131063998"}}, "name": "Not Milkinho Chocolate Leite Vegetal 200ml", "website": "https://www.covabra.com.br/not-milkinho-chocolate-leite-vegetal-200ml/p", "image": "https://covabra.vtexassets.com/arquivos/ids/539273/85892.jpg?v=638953718921700000", "ref": "00019995", "offers": [{"@type": "AggregateOffer", "lowPrice": 3.99, "highPrice": 3.99, "priceCurrency": "BRL", "offers": [{"@type": "Offer", "price": 3.99, "priceCurrency": "BRL", "availability": "http://schema.org/InStock", "sku": "00019995", "itemCondition": "http://schema.org/NewCondition", "priceValidUntil": "2027-06-30T00:00:00Z", "seller": {"@type": "Organization", "name": "COVABRA SUPERMERCADOS - BR"}}], "offerCount": 1}], "brand_wikidata": "Q131063998"}
]
```

---
*PR created automatically by Jules for task [5167815913200074652](https://jules.google.com/task/5167815913200074652) started by @CloCkWeRX*