### PR TITLE
Add Polomarket (Poland) spider

### DIFF
--- a/products/spiders/polomarket_pl.py
+++ b/products/spiders/polomarket_pl.py
@@ -1,0 +1,95 @@
+import re
+
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class PolomarketPLSpider(CrawlSpider, StructuredDataSpider):
+    """
+    Spider for Polomarket (Poland).
+    Wikidata: Q11821937
+
+    This site uses Nuxt.js but product data is primarily extracted from HTML
+    due to complexity in parsing the hydration state.
+    """
+
+    name = "polomarket_pl"
+    allowed_domains = ["polomarket.pl"]
+    start_urls = ["https://www.polomarket.pl/"]
+
+    item_attributes = {
+        "brand_wikidata": "Q11821937",
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q11821937",
+                "name": "Polomarket",
+            }
+        },
+    }
+
+    rules = (
+        Rule(LinkExtractor(allow=r"/produkty/[^/]+$"), callback="parse_sd"),
+        Rule(
+            LinkExtractor(
+                allow=(
+                    r"/oferta-lojalnosciowa",
+                    r"/gazetki",
+                    r"/nasze-marki",
+                )
+            ),
+            follow=True,
+        ),
+    )
+
+    def iter_linked_data(self, response):
+        # Fallback to standard LD-JSON if any
+        yield from super().iter_linked_data(response)
+
+        name = response.css("h1::text").get()
+        if name:
+            name = name.strip()
+
+            # Primary price (often promo price)
+            price_integer = response.css(".price-main__actual::text").get()
+            price_decimal = response.css(".price-main__actual sup::text").get()
+
+            price = None
+            if price_integer:
+                price = price_integer.strip()
+                if price_decimal:
+                    price += "." + price_decimal.strip()
+
+            # Fallback to Regular price if main price not found or to keep as extra
+            reg_price_text = response.xpath(
+                '//span[contains(text(), "Cena regularna")]/text()'
+            ).get()
+            if not price and reg_price_text:
+                m = re.search(r"(\d+\.\d+)", reg_price_text)
+                if m:
+                    price = m.group(1)
+
+            image = response.css(".image-container img::attr(src)").get()
+
+            yield {
+                "@type": "Product",
+                "name": name,
+                "image": response.urljoin(image) if image else None,
+                "offers": {
+                    "@type": "Offer",
+                    "price": price,
+                    "priceCurrency": "PLN",
+                    "availability": "https://schema.org/InStock",
+                },
+                "url": response.url,
+            }
+
+    def post_process_item(self, item, response, ld_data):
+        if not item.get("ref"):
+            # Use slug from URL as reference
+            ref = response.url.split("/")[-1]
+            item["ref"] = ref
+
+        yield from super().post_process_item(item, response, ld_data)


### PR DESCRIPTION
This PR adds a new scraper for Polomarket (Poland) as requested in #335.

The spider uses bespoke HTML parsing to extract product names and prices, as the site's Nuxt.js hydration state was found to be excessively complex for robust parsing with current tools within the project's constraints.

Sample output data:
```json
{
  "brand_wikidata": "Q11821937",
  "extras": {
    "@source_uri": "https://polomarket.pl/produkty/maska-pelnotwarzowa-do-nurkowania-flying-mike-1",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q11821937",
      "@type": "Organization",
      "name": "Polomarket"
    }
  },
  "image": "https://static.polo.appchance.shop/cdn-cgi/image/f=auto,q=80,dpr=1/filer_public/21/97/2197fbf5-5623-4cfa-acef-e74f8b009fd8/0087662.jpg",
  "name": "Maska pełnotwarzowa do nurkowania Flying Mike",
  "offers": [
    {
      "@type": "Offer",
      "availability": "https://schema.org/InStock",
      "price": "79.99",
      "priceCurrency": "PLN"
    }
  ],
  "ref": "/produkty/maska-pelnotwarzowa-do-nurkowania-flying-mike-1",
  "website": "https://polomarket.pl/produkty/maska-pelnotwarzowa-do-nurkowania-flying-mike-1"
}
```

---
*PR created automatically by Jules for task [12318015069312773739](https://jules.google.com/task/12318015069312773739) started by @CloCkWeRX*