### PR TITLE
Add PLUS (Netherlands) spider

### DIFF
--- a/products/spiders/plus_nl.py
+++ b/products/spiders/plus_nl.py
@@ -1,0 +1,82 @@
+from scrapy import Request
+from scrapy.spiders import SitemapSpider
+from scrapy_playwright.page import PageMethod
+from products.items import Product
+
+
+class PlusNLSpider(SitemapSpider):
+    name = "plus_nl"
+    allowed_domains = ["plus.nl"]
+    sitemap_urls = ["https://www.plus.nl/ECP_Sitemap_Engine/rest/Sitemap/index"]
+    sitemap_rules = [
+        (r"/product/", "parse_product"),
+    ]
+
+    custom_settings = {
+        "PLAYWRIGHT_LAUNCH_OPTIONS": {"headless": True},
+        "DOWNLOAD_HANDLERS": {
+            "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+            "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+        },
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0",
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 60000,
+        "PLAYWRIGHT_BROWSER_TYPE": "firefox",
+        "CONCURRENT_REQUESTS": 2,
+    }
+
+    def _parse_sitemap(self, response):
+        if "index" in response.url:
+            for sitemap in response.xpath("//*[local-name()='sitemap']"):
+                loc = sitemap.xpath("./*[local-name()='loc']/text()").get()
+                if "product" in loc:
+                    yield Request(loc, callback=self._parse_sitemap)
+        else:
+            for request_or_item in super()._parse_sitemap(response):
+                if isinstance(request_or_item, Request):
+                    if "/product/" in request_or_item.url:
+                        request_or_item.meta["playwright"] = True
+                        request_or_item.meta["playwright_include_body"] = True
+                        request_or_item.meta["playwright_page_methods"] = [
+                            PageMethod("wait_for_selector", ".btn-cookies-accept", timeout=20000),
+                            PageMethod("click", ".btn-cookies-accept"),
+                            PageMethod("wait_for_selector", "h1 span.js-screen-title", timeout=20000),
+                        ]
+                    yield request_or_item
+                else:
+                    yield request_or_item
+
+    def parse_product(self, response):
+        product = Product()
+        product["website"] = response.url
+
+        # Name
+        name = response.css("h1 span.js-screen-title::text").get()
+        if not name:
+            name = response.css("h1::text").get()
+        product["name"] = name.strip() if name else None
+
+        # Price
+        price_integer = response.css(".product-header-price-integer span::text").get()
+        price_decimals = response.css(".product-header-price-decimals span::text").get()
+        if price_integer and price_decimals:
+            price_integer = price_integer.replace(".", "").strip()
+            price_str = f"{price_integer}.{price_decimals.strip()}"
+            try:
+                product["price"] = float(price_str)
+            except ValueError:
+                pass
+
+        # Image
+        image = response.css(".product-header-image img::attr(src)").get()
+        product["image"] = image
+
+        # Ref
+        ref = response.url.split("-")[-1]
+        product["ref"] = ref
+
+        product["located_in_wikidata"] = "Q1978981"
+        product["proof_currency"] = "EUR"
+
+        if product.get("name"):
+            yield product


### PR DESCRIPTION
I have implemented a new Scrapy spider for PLUS (Netherlands) (plus.nl), addressing issue #258.

The spider utilizes `SitemapSpider` to discover product URLs from the site's sitemap index. Due to the site being an OutSystems Single Page Application (SPA) with a cookie wall, `scrapy-playwright` with Firefox is used to:
1. Accept the cookie wall by clicking the `.btn-cookies-accept` button.
2. Wait for the dynamic content (product name and price) to hydrate before parsing.

Wikidata ID `Q1978981` has been attributed to the retailer.

Sample structured data output:
```json
{
    "extras": {
        "@source_uri": "https://www.plus.nl/product/bokma-graanjenever-fles-1000-ml-100028"
    },
    "website": "https://www.plus.nl/product/bokma-graanjenever-fles-1000-ml-100028",
    "name": "Bokma Graanjenever",
    "price": 17.49,
    "image": "https://images.ctfassets.net/s0lodsnpsezb/100028_M/04acb1e50ae0035eba6dbd181a4a9054/100028.png?w=380&h=380&fit=pad&q=85",
    "ref": "100028",
    "located_in_wikidata": "Q1978981",
    "proof_currency": "EUR"
}
```

---
*PR created automatically by Jules for task [13671695740356748511](https://jules.google.com/task/13671695740356748511) started by @CloCkWeRX*