### PR TITLE
Add Jumbo Chile scraper (jumbo.cl)

### DIFF
--- a/products/spiders/jumbo_cl.py
+++ b/products/spiders/jumbo_cl.py
@@ -1,0 +1,69 @@
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+class JumboCLSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Jumbo (Chile).
+    Extracts product data from Schema.org JSON-LD.
+
+    Sample output:
+    {
+        "brand": "Evian",
+        "brand_wikidata": "Q6310864",
+        "extras": {
+            "@source_uri": "https://www.jumbo.cl/agua-mineral-sin-gas-evian-1-l-botella-desechable/p",
+            "owner": {
+                "@id": "https://www.wikidata.org/wiki/Q1053351",
+                "@type": "Organization",
+                "name": "Cencosud"
+            }
+        },
+        "gtin": "61314000070",
+        "image": "https://jumbocl.vtexassets.com/arquivos/ids/297560-250-250/Principal-3453.jpg?v=638775740696900000",
+        "name": "Agua Evian Mineral Sin Gas 1 L",
+        "offers": [
+            {
+                "@type": "Offer",
+                "availability": "https://schema.org/InStock",
+                "itemCondition": "https://schema.org/NewCondition",
+                "price": "2392",
+                "priceCurrency": "CLP",
+                "seller": {
+                    "@type": "Organization",
+                    "name": "Jumbo.cl"
+                },
+                "url": "https://jumbo.cl/agua-mineral-sin-gas-evian-1-l-botella-desechable/p"
+            }
+        ],
+        "ref": "12",
+        "website": "https://www.jumbo.cl/agua-mineral-sin-gas-evian-1-l-botella-desechable/p"
+    }
+    """
+
+    name = "jumbo_cl"
+    allowed_domains = ["jumbo.cl"]
+    user_agent = FIREFOX_LATEST
+
+    sitemap_urls = ["https://www.jumbo.cl/sitemap.xml"]
+    sitemap_rules = [
+        (r"/p$", "parse_sd"),
+    ]
+
+    item_attributes = {
+        "brand_wikidata": "Q6310864",
+        "extras": {
+            "owner": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q1053351",
+                "name": "Cencosud",
+            }
+        },
+    }
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        if "gtin" in ld_data:
+            item["gtin"] = ld_data["gtin"]
+        if "brand" in ld_data and isinstance(ld_data["brand"], dict):
+            item["brand"] = ld_data["brand"].get("name")
+        yield item


### PR DESCRIPTION
Implementation of a scraper for jumbo.cl using `SitemapSpider` and `StructuredDataSpider`. 

Features:
- Discovery via sitemap index.
- Extraction from Schema.org JSON-LD.
- Refined extraction for `gtin` and `brand` in `post_process_item`.
- Wikidata attribution for Jumbo (Q6310864) and Cencosud (Q1053351).

Sample output:
```json
{
    "extras": {
        "@source_uri": "https://www.jumbo.cl/tabla-quilla-200g/p",
        "owner": {
            "@type": "Organization",
            "@id": "https://www.wikidata.org/wiki/Q1053351",
            "name": "Cencosud"
        }
    },
    "name": "Tabla de Quesos Quillayes Selección N°6 - 200 g | Jumbo.cl",
    "website": "https://www.jumbo.cl/tabla-quilla-200g/p",
    "image": "https://jumbocl.vtexassets.com/arquivos/ids/404868-250-250/TABLA-QUILLA-200G.jpg?v=638779826740970000",
    "ref": "147497",
    "offers": [
        {
            "@type": "Offer",
            "price": "8350",
            "priceCurrency": "CLP",
            "url": "https://jumbo.cl/tabla-quilla-200g/p",
            "itemCondition": "https://schema.org/NewCondition",
            "availability": "https://schema.org/InStock",
            "seller": {
                "@type": "Organization",
                "name": "Jumbo.cl"
            }
        }
    ],
    "gtin": "7800155548876",
    "brand": "Krea",
    "brand_wikidata": "Q6310864"
}
```

---
*PR created automatically by Jules for task [15760813154594631942](https://jules.google.com/task/15760813154594631942) started by @CloCkWeRX*