### PR TITLE
Add Mercator (Slovenia) spider

### DIFF
--- a/products/spiders/mercator_si.py
+++ b/products/spiders/mercator_si.py
@@ -1,0 +1,68 @@
+import json
+import re
+from typing import Iterable
+
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+
+
+class MercatorSISpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Mercator (Slovenia).
+    Extracts product data from the `analyticsObject` JavaScript variable as the site lacks standard Schema.org JSON-LD.
+
+    Sample output:
+    {
+        "name": "Margarina, Zvijezda, 250 g",
+        "website": "https://mercatoronline.si/izdelek/22419/margarina-zvijezda-250-g",
+        "image": "https://mercatoronline.si/img/cache/products/4909/product_medium_image/00000040.jpg",
+        "ref": "22419",
+        "brand": "ZVIJEZDA",
+        "located_in_wikidata": "Q1366974",
+        "price": 1.09,
+        "proof_currency": "EUR",
+        "offers": [
+            {
+                "@type": "Offer",
+                "price": 1.09,
+                "priceCurrency": "EUR"
+            }
+        ],
+        "extras": {}
+    }
+    """
+
+    name = "mercator_si"
+    allowed_domains = ["mercatoronline.si"]
+    sitemap_urls = ["https://mercatoronline.si/sitemap.xml"]
+    sitemap_rules = [(r"/izdelek/(\d+)/", "parse_sd")]
+
+    def iter_linked_data(self, response) -> Iterable[dict]:
+        # The site does not provide standard Schema.org JSON-LD in static HTML.
+        # We extract product data from the analyticsObject variable used for GA4.
+        match = re.search(r"var analyticsObject = (\{.*?});", response.text, re.DOTALL)
+        if match:
+            try:
+                data = json.loads(match.group(1))
+                items = data.get("ecommerce", {}).get("items", [])
+                if items:
+                    product_data = items[0]
+                    yield {
+                        "@context": "https://schema.org",
+                        "@type": "Product",
+                        "name": product_data.get("item_name"),
+                        "sku": str(product_data.get("item_id")),
+                        "brand": {"@type": "Brand", "name": product_data.get("item_brand")},
+                        "offers": {
+                            "@type": "Offer",
+                            "price": product_data.get("price"),
+                            "priceCurrency": product_data.get("currency", "EUR"),
+                        },
+                    }
+            except json.JSONDecodeError:
+                self.logger.warning("Failed to parse analyticsObject JSON")
+
+    def post_process_item(self, item, response, ld_data):
+        item["located_in_wikidata"] = "Q1366974"
+        item["proof_currency"] = "EUR"
+        yield item


### PR DESCRIPTION
This PR adds a new spider for the Slovenian retailer Mercator (mercatoronline.si).

The site lacks standard Schema.org JSON-LD in its static HTML. Instead, it provides product data within a JavaScript variable `analyticsObject` used for GA4. The spider extracts this data using regex and maps it to the internal `Product` item.

Discovery is handled via the sitemap at `https://mercatoronline.si/sitemap.xml`.

Sample output:
```json
{
    "extras": {"@source_uri": "https://mercatoronline.si/izdelek/22419/margarina-zvijezda-250-g"},
    "name": "Margarina, Zvijezda, 250 g",
    "website": "https://mercatoronline.si/izdelek/22419/margarina-zvijezda-250-g",
    "ref": "22419",
    "image": "https://mercatoronline.si/img/cache/products/4909/product_medium_image/00000040.jpg",
    "offers": [{"@type": "Offer", "price": 1.09, "priceCurrency": "EUR"}],
    "located_in_wikidata": "Q1366974",
    "proof_currency": "EUR"
}
```

Fix #360

---
*PR created automatically by Jules for task [2043797011550300683](https://jules.google.com/task/2043797011550300683) started by @CloCkWeRX*