### PR TITLE
Add lupa_es spider for Lupa (Spain) #365

### DIFF
--- a/products/spiders/lupa_es.py
+++ b/products/spiders/lupa_es.py
@@ -1,0 +1,58 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class LupaESSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Scraper for Lupa (Spain).
+    https://www.lupaonline.com/
+
+    Sample output:
+    {
+        "name": "Aceite Abril Oliva Intenso Litro",
+        "website": "https://www.lupaonline.com/santander/aceite-abril-oliva-intenso-lt-102108",
+        "image": "https://www.lupaonline.com/media/catalog/product/cache/0b22c8a128ee9aeccd1570def5c6617a/1/0/102108_2.jpg",
+        "ref": "102108",
+        "sku": "102108",
+        "offers": [
+            {
+                "@type": "Offer",
+                "url": "https://www.lupaonline.com/santander/aceite-abril-oliva-intenso-lt-102108",
+                "priceCurrency": "EUR",
+                "price": "3.95",
+                "availability": "https://schema.org/InStock",
+                "itemCondition": "https://schema.org/NewCondition",
+                "seller": {"@id": "https://www.lupaonline.com/santander/#organization"}
+            }
+        ],
+        "proof_currency": "EUR",
+        "price": 3.95,
+        "located_in_wikidata": "Q12267744"
+    }
+    """
+
+    name = "lupa_es"
+    allowed_domains = ["lupaonline.com"]
+    sitemap_urls = ["https://www.lupaonline.com/media/sitemap/sitemap_santande.xml"]
+    sitemap_rules = [
+        (r"-(\d+)$", "parse_sd"),
+    ]
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    item_attributes = {
+        "proof_currency": "EUR",
+        "located_in_wikidata": "Q12267744",
+    }
+
+    def post_process_item(self, item, response, ld_data):
+        if item.get("offers"):
+            price = item["offers"][0].get("price")
+            if price:
+                item["price"] = float(price)
+        yield item


### PR DESCRIPTION
Implemented a new Scrapy spider for Lupa (Spain) supermarkets.
The spider uses the sitemap at `https://www.lupaonline.com/media/sitemap/sitemap_santande.xml` to discover products and extracts structured data (JSON-LD) from product pages.
It includes bespoke logic to extract the top-level price and handles the retailer's Wikidata attribution.
Verified with a 2-minute crawl and individual product parsing.

Sample output:
```json
{
  "name": "Aceite Abril Oliva Intenso Litro",
  "website": "https://www.lupaonline.com/santander/aceite-abril-oliva-intenso-lt-102108",
  "image": "https://www.lupaonline.com/media/catalog/product/cache/0b22c8a128ee9aeccd1570def5c6617a/1/0/102108_2.jpg",
  "ref": "102108",
  "sku": "102108",
  "offers": [
    {
      "@type": "Offer",
      "url": "https://www.lupaonline.com/santander/aceite-abril-oliva-intenso-lt-102108",
      "priceCurrency": "EUR",
      "price": "3.95",
      "availability": "https://schema.org/InStock",
      "itemCondition": "https://schema.org/NewCondition",
      "seller": {"@id": "https://www.lupaonline.com/santander/#organization"}
    }
  ],
  "proof_currency": "EUR",
  "price": 3.95,
  "located_in_wikidata": "Q12267744"
}
```

---
*PR created automatically by Jules for task [5828831361706064801](https://jules.google.com/task/5828831361706064801) started by @CloCkWeRX*