### PR TITLE
Add frac_pl spider for FRAC (Poland)

### DIFF
--- a/products/spiders/frac_pl.py
+++ b/products/spiders/frac_pl.py
@@ -1,0 +1,46 @@
+from scrapy.spiders import Rule, CrawlSpider
+from scrapy.linkextractors import LinkExtractor
+from products.structured_data_spider import StructuredDataSpider
+from products.items import Product
+from scrapy.http import Response
+
+class FracPLSpider(CrawlSpider, StructuredDataSpider):
+    """
+    Spider for FRAC (Poland).
+    Wikidata: Q11698715
+    Fixes #53.
+
+    Sample output:
+    {
+        "name": "DOLNOŚLĄSKA MĄKA POZNAŃSKA 1 kg",
+        "price": 2.99,
+        "priceCurrency": "PLN",
+        "website": "https://www.fracfrac.pro-linuxpl.com/DOLNOSLASKA-MAKA-POZNANSKA-1-kg,p,101884",
+        "image": "https://www.fracfrac.pro-linuxpl.com/images/3000-4000/DOLNOSLASKA-MAKA-POZNANSKA-WOSEB_[3464]_1200.jpg",
+        "ref": "101884",
+        "located_in_wikidata": "Q11698715"
+    }
+    """
+    name = "frac_pl"
+    allowed_domains = ["fracfrac.pro-linuxpl.com"]
+    start_urls = ["https://www.fracfrac.pro-linuxpl.com/"]
+
+    item_attributes = {
+        "located_in_wikidata": "Q11698715"
+    }
+
+    rules = (
+        Rule(LinkExtractor(allow=r",c,\d+")),
+        Rule(LinkExtractor(allow=r",p,(\d+)"), callback="parse_sd"),
+    )
+
+    def post_process_item(self, item: Product, response: Response, ld_data: dict, **kwargs):
+        if not item.get("image"):
+            item["image"] = response.css("#href_gallery_image::attr(data-src)").get() or response.css(".mainImage::attr(src)").get()
+
+        if item.get("image") and item["image"].startswith("/"):
+            item["image"] = response.urljoin(item["image"])
+
+        item["located_in_wikidata"] = self.item_attributes["located_in_wikidata"]
+
+        yield item


### PR DESCRIPTION
Implemented a new Scrapy spider for the FRAC supermarket chain in Poland, addressing issue #53. The spider utilizes `CrawlSpider` and `StructuredDataSpider` to discover and extract product data from the store's website. Wikidata information (Q11698715) has been included. Verified the implementation with a test crawl.

---
*PR created automatically by Jules for task [4463399059460693171](https://jules.google.com/task/4463399059460693171) started by @CloCkWeRX*