### PR TITLE
Add bim_tr spider for BİM (Turkey) (Fix #394)

### DIFF
--- a/products/spiders/bim_tr.py
+++ b/products/spiders/bim_tr.py
@@ -1,0 +1,73 @@
+import re
+from scrapy.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from products.items import Product
+from products.user_agents import FIREFOX_LATEST
+
+class BimTRSpider(CrawlSpider):
+    """
+    Spider for BİM (Turkey).
+    Wikidata: Q1022075
+    """
+    name = "bim_tr"
+    allowed_domains = ["bim.com.tr"]
+    start_urls = ["https://www.bim.com.tr/"]
+
+    user_agent = FIREFOX_LATEST
+
+    rules = (
+        # Categories
+        Rule(LinkExtractor(allow=(r"/Categories/\d+/.*", r"/urunler/.*/categories\.aspx", r"/Markalar/\d+/.*"))),
+        # Products
+        Rule(LinkExtractor(allow=(r"/aktuel-urunler/.*/aktuel\.aspx", r"/urunler/.*/product\.aspx")), callback="parse_product"),
+    )
+
+    def parse_product(self, response):
+        item = Product()
+
+        # The product name is typically in .titleArea h2.title
+        name = response.css(".titleArea h2.title::text").get()
+        if not name:
+            # Fallback
+            name = response.css("h2.title::text").get()
+
+        if not name:
+            return
+
+        item["name"] = name.strip()
+        item["website"] = response.url
+
+        image = response.css(".leftSide .imageArea img::attr(src)").get()
+        if image:
+            item["image"] = response.urljoin(image)
+
+        # Price extraction
+        quantify = response.css(".priceArea .quantify::text").get()
+        number = response.css(".priceArea .number::text").get()
+
+        if quantify and number:
+            # Price format: "399," + "00" -> "399.00"
+            # Cleanup quantify: might have dots for thousands separator
+            price_str = quantify.replace(".", "").replace(",", "") + "." + number
+            item["price"] = price_str
+            item["proof_currency"] = "TRY"
+
+        ref = response.css(".shareArea a::attr(data-id)").get()
+        if ref:
+            item["ref"] = ref
+        else:
+            # Fallback to URL slug
+            match = re.search(r"/([^/]+)/(aktuel|product)\.aspx$", response.url)
+            if match:
+                item["ref"] = match.group(1)
+
+        item["located_in_wikidata"] = "Q1022075"
+
+        # Limit description to the actual product info area to avoid noise from other products
+        description = response.css(".detailArea .textArea ::text").getall()
+        if description:
+            desc_text = " ".join([d.strip() for d in description if d.strip()])
+            if desc_text:
+                item["description"] = desc_text
+
+        yield item


### PR DESCRIPTION
I have implemented a new Scrapy spider for BİM (Turkey) as requested in issue #394.

### Changes:
- Created `products/spiders/bim_tr.py`.
- Used `CrawlSpider` to discover products through category and brand links.
- Implemented bespoke HTML parsing for names, prices, images, and references.
- Added Wikidata information (`Q1022075`).
- Ensured prices are correctly parsed from the Turkish currency format.

### Verification:
- Ran the spider with a 2-minute timeout: `uv run scrapy crawl bim_tr -o bim_tr.json`.
- Verified that it successfully crawls and extracts structured product data.
- Checked naming consistency using `ci/check_spider_naming_consistency.py`.

### Sample Output:
```json
{
 "description": "• 1000 g",
 "image": "https://cdn1.bim.com.tr/uploads/aktuel-urunler/1600_buyuk_543X467_1204_gda_0047_vector-smart-object.jpg",
 "located_in_wikidata": "Q1022075",
 "name": "TAM YAĞLI TAZE KAŞAR PEYNİRİ",
 "price": "399.00",
 "proof_currency": "TRY",
 "ref": "67361",
 "website": "https://www.bim.com.tr/aktuel-urunler/tam-yagli-taze-kasar-peyniri-22-6/aktuel.aspx"
}
```

Fix #394

---
*PR created automatically by Jules for task [9060644298438591914](https://jules.google.com/task/9060644298438591914) started by @CloCkWeRX*