### PR TITLE
Add emart_kr spider for Emart (South Korea)

### DIFF
--- a/products/spiders/emart_kr.py
+++ b/products/spiders/emart_kr.py
@@ -1,0 +1,35 @@
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+class EmartKRSpider(SitemapSpider, StructuredDataSpider):
+    name = "emart_kr"
+    allowed_domains = ["emart.ssg.com", "ssg.com"]
+    sitemap_urls = ["https://emart.ssg.com/sitemap/emart-sitemap.xml"]
+    sitemap_rules = [(r"itemId=(\d+)", "parse")]
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+        "ROBOTSTXT_OBEY": False,
+    }
+
+    located_in_wikidata = "Q490333"
+
+    def post_process_item(self, item, response, ld_data):
+        # Prepend https:// to image URLs if they start with sitem.ssgcdn.com
+        images = item.get("image")
+        if images:
+            new_images = []
+            if isinstance(images, str):
+                images = [images]
+            for img in images:
+                if img.startswith("sitem.ssgcdn.com"):
+                    new_images.append("https://" + img)
+                else:
+                    new_images.append(img)
+            item["image"] = new_images
+
+        # Ensure the currency is set to KRW
+        item["proof_currency"] = "KRW"
+
+        yield item


### PR DESCRIPTION
This pull request adds a new Scrapy spider for Emart (South Korea), a major retailer. 

The spider:
- Inherits from `SitemapSpider` and `StructuredDataSpider`.
- Targets product pages via the official sitemap index.
- Normalizes image URLs by prepending `https://` where missing.
- Sets the currency to `KRW`.
- Attributes the retailer with Wikidata ID `Q490333`.

Sample structured data output:
```json
{
  "extras": {"@source_uri": "https://emart.ssg.com/item/itemView.ssg?itemId=1000268665123"},
  "image": ["https://sitem.ssgcdn.com/23/51/66/item/1000268665123_i1_1200.jpg"],
  "name": "애플토마토 600g 팩",
  "offers": [{
    "@id": "https://www.ssg.com/item/itemView.ssg?itemId=1000268665123#offer",
    "@type": "Offer",
    "price": 5980,
    "priceCurrency": "KRW",
    "url": "https://www.ssg.com/item/itemView.ssg?itemId=1000268665123"
  }],
  "proof_currency": "KRW",
  "ref": "1000268665123",
  "website": "https://www.ssg.com/item/itemView.ssg?itemId=1000268665123"
}
```

Fix #44

---
*PR created automatically by Jules for task [12230237416045405239](https://jules.google.com/task/12230237416045405239) started by @CloCkWeRX*