### PR TITLE
Fix #77: Extract GTIN from image URL in Harris Farm Markets

### DIFF
--- a/products/spiders/harris_farm_au.py
+++ b/products/spiders/harris_farm_au.py
@@ -1,3 +1,5 @@
+import re
+
 from scrapy.spiders import SitemapSpider
 
 from products.structured_data_spider import StructuredDataSpider
@@ -20,3 +22,11 @@ class HarrisFarmAUSpider(SitemapSpider, StructuredDataSpider):
     sitemap_rules = [
         (r"https://www.harrisfarm.com.au/products/[\w-]+", "parse_sd"),
     ]
+
+    def post_process_item(self, item, response, ld_data):
+        image_url = item.get("image")
+        if image_url:
+            match = re.search(r"GTIN(\d{8,14})", image_url, re.IGNORECASE)
+            if match:
+                item["gtin"] = match.group(1)
+        yield from super().post_process_item(item, response, ld_data)


### PR DESCRIPTION
This PR addresses issue #77 by implementing a custom `post_process_item` hook in the `HarrisFarmAUSpider` class inside `products/spiders/harris_farm_au.py`.
Some, but not all products on Harris Farm Markets have their barcode/GTIN embedded in the image URL using the pattern `GTIN` followed by 8 to 14 digits (e.g. `GTIN9369998268177`).
The implemented regex parses this and assigns the found value to the product's `gtin` field.

Sample output structured data:
```json
{
  "extras": {
    "@source_uri": "https://www.harrisfarm.com.au/products/chocd-full-coconut-rough-200g-66899",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q5664888",
      "@type": "Organization",
      "name": "Harris Farm Markets"
    }
  },
  "name": "Choc'd Full Coconut Rough 200g",
  "website": "https://www.harrisfarm.com.au/products/chocd-full-coconut-rough-200g-66899",
  "image": "https://www.harrisfarm.com.au/cdn/shop/files/GTIN9369998268177_Coconut_Rough_0001_-removebg-preview_70f864b5-9692-41b4-b3ce-a50b88dd5f25.png?v=1717662809&width=1920",
  "ref": "66899",
  "gtin": "9369998268177",
  "offers": [
    ...
  ]
}
```

---
*PR created automatically by Jules for task [6896987934976671118](https://jules.google.com/task/6896987934976671118) started by @CloCkWeRX*