### PR TITLE
Add foodmaxx_us spider. Fix #466

### DIFF
--- a/products/spiders/foodmaxx_us.py
+++ b/products/spiders/foodmaxx_us.py
@@ -1,0 +1,150 @@
+import base64
+import json
+import re
+import scrapy
+from urllib.parse import unquote
+from products.items import Product
+from products.user_agents import FIREFOX_LATEST
+
+class FoodmaxxUSSpider(scrapy.Spider):
+    """
+    FoodMaxx (United States) spider.
+    Wikidata: Q5465421
+
+    This spider uses the Swiftly API to fetch product data with prices.
+    It first visits the categories page to obtain a session token from the __session cookie.
+    """
+    name = "foodmaxx_us"
+    allowed_domains = ["foodmaxx.com", "swiftlyapi.net"]
+
+    # Store ID 401 has valid products/prices
+    store_id = "401"
+    api_base_url = "https://fm.swiftlyapi.net/search/api/v1/products/categories"
+
+    custom_settings = {
+        "USER_AGENT": FIREFOX_LATEST,
+        "ROBOTSTXT_OBEY": False,
+        "CONCURRENT_REQUESTS": 2,
+    }
+
+    def start_requests(self):
+        # Initial request to get the __session cookie
+        yield scrapy.Request(
+            "https://foodmaxx.com/",
+            callback=self.parse_session
+        )
+
+    def parse_session(self, response):
+        session_cookies = response.headers.getlist('Set-Cookie')
+        token = None
+        for cookie_bytes in session_cookies:
+            cookie_str = cookie_bytes.decode('utf-8')
+            if '__session=' in cookie_str:
+                match = re.search(r'__session=([^;]*)', cookie_str)
+                if match:
+                    encoded_session = unquote(match.group(1))
+                    try:
+                        # The cookie is base64 encoded JSON followed by a signature (sometimes multiple parts)
+                        # We only need the first part which is the JSON payload
+                        payload = encoded_session.split('.')[0]
+                        payload += '=' * ((4 - len(payload) % 4) % 4)
+                        session_data = json.loads(base64.urlsafe_b64decode(payload).decode('utf-8', errors='ignore'))
+                        token = session_data.get('token')
+                        if token:
+                            break
+                    except Exception:
+                        continue
+
+        if not token:
+            self.logger.error("Could not extract token from __session cookie")
+            return
+
+        # List of top level categories matching the sitemap or taxonomies
+        categories = [
+            "Product/baby_needs", "Product/beer_wine_spirits", "Product/beverage",
+            "Product/bread_bakery", "Product/dairy_eggs_cheese", "Product/deli_counter",
+            "Product/floral_garden", "Product/frozen_foods", "Product/health_beauty",
+            "Product/household", "Product/juice_bar", "Product/meat_seafood",
+            "Product/pantry", "Product/pet_care", "Product/produce",
+            "Product/seasonal_merchandise", "Product/snacks"
+        ]
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "Origin": "https://foodmaxx.com",
+            "Referer": "https://foodmaxx.com/",
+            "x-swiftly-banner-id": "ed5181c4-4323-4bac-9e4a-e5ca92c3de68",
+        }
+
+        for cat in categories:
+            url = f"{self.api_base_url}?cat={cat.replace('/', '%2F')}&store={self.store_id}&limit=100&offset=0"
+            yield scrapy.Request(
+                url,
+                headers=headers,
+                callback=self.parse_api,
+                meta={'token': token, 'cat': cat, 'offset': 0, 'headers': headers}
+            )
+
+    def parse_api(self, response):
+        data = response.json()
+        # In the Swiftly API, products are under products -> items
+        products_info = data.get('products', {})
+        products = products_info.get('items', [])
+
+        for p_data in products:
+            product = Product()
+            product["name"] = p_data.get("name")
+            product["ref"] = p_data.get("id")
+            # Build website URL
+            product["website"] = f"https://foodmaxx.com/categories/{response.meta['cat'].replace('/', '%2F')}/product/{p_data.get('id')}"
+            product["description"] = p_data.get("description")
+            product["brand"] = p_data.get("brand")
+
+            if primary_image := p_data.get("primaryImage"):
+                product["image"] = primary_image.get("url")
+
+            price_info = p_data.get("price", {}).get("ok", {})
+            if price_info:
+                reg_text = price_info.get("regPriceText", "")
+                promo_text = price_info.get("promoArea", {}).get("promoText", "")
+
+                # Simple extraction of price from text (e.g. "$3.99" or "$5")
+                price_match = re.search(r'\$(\d+(?:\.\d{2})?)', promo_text or reg_text)
+                if price_match:
+                    product["price"] = price_match.group(1)
+                    product["proof_currency"] = "USD"
+
+                if promo_text:
+                    product["price_is_discounted"] = True
+                    reg_match = re.search(r'\$(\d+(?:\.\d{2})?)', reg_text)
+                    if reg_match:
+                        product["price_without_discount"] = reg_match.group(1)
+
+            # GTIN extraction from productCodes
+            if codes := p_data.get("productCodes"):
+                if isinstance(codes, list):
+                    # Usually the first is the 14-digit GTIN or similar
+                    for code in codes:
+                        if len(code) >= 12:
+                            product["gtin"] = code
+                            break
+
+            product["located_in_wikidata"] = "Q5465421"
+            yield product
+
+        # Pagination
+        if len(products) == 100:
+            new_offset = response.meta['offset'] + 100
+            url = f"{self.api_base_url}?cat={response.meta['cat'].replace('/', '%2F')}&store={self.store_id}&limit=100&offset={new_offset}"
+            yield scrapy.Request(
+                url,
+                headers=response.meta['headers'],
+                callback=self.parse_api,
+                meta={
+                    'token': response.meta['token'],
+                    'cat': response.meta['cat'],
+                    'offset': new_offset,
+                    'headers': response.meta['headers']
+                }
+            )


### PR DESCRIPTION
Add foodmaxx_us spider. Fix #466

Implement an API-driven spider for FoodMaxx (United States) supermarket chain (Wikidata: Q5465421) under the name `foodmaxx_us`.

The spider requests the homepage to extract the anonymous JWT token from the `__session` cookie. It then uses this bearer token to query the paginated public Swiftly categories endpoint for active products and pricing at store ID `401`.

Sample output structured data:
```json
{
  "name": "Corn Tortilla Chips",
  "ref": "72524",
  "website": "https://foodmaxx.com/categories/Product%2Fsnacks/product/72524",
  "description": "Calidad , Corn Tortilla Chips ",
  "brand": "CALIDAD",
  "image": "https://assets.swiftlycontent.net/assets/product/7060608_406936d7-56fa-4bd5-acf8-4f4471a3f314.jpg",
  "price": "1.79",
  "proof_currency": "USD",
  "price_is_discounted": true,
  "price_without_discount": "2.69",
  "gtin": "00077948009068",
  "located_in_wikidata": "Q5465421"
}
```

---
*PR created automatically by Jules for task [1056667470398687963](https://jules.google.com/task/1056667470398687963) started by @CloCkWeRX*