### PR TITLE
Add Food Basics (Canada) spider (Fix #464)

### DIFF
--- a/products/spiders/foodbasics_ca.py
+++ b/products/spiders/foodbasics_ca.py
@@ -1,0 +1,93 @@
+import re
+from scrapy import Request
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class FoodbasicsCASpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Food Basics (Canada).
+    Extracts product data from Schema.org Product data.
+    Uses Playwright to bypass Cloudflare.
+
+    Sample output:
+    {
+        "name": "Boneless Skinless Chicken Breasts",
+        "website": "https://www.foodbasics.ca/aisles/meat-poultry/chicken-turkey/breasts/boneless-skinless-chicken-breasts/p/244452",
+        "ref": "244452",
+        "offers": [
+            {
+                "@type": "Offer",
+                "price": "14.99",
+                "priceCurrency": "CAD",
+                "availability": "https://schema.org/InStock"
+            }
+        ],
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q5465300",
+                "name": "Food Basics"
+            }
+        }
+    }
+    """
+
+    name = "foodbasics_ca"
+    allowed_domains = ["foodbasics.ca"]
+    sitemap_urls = ["https://www.foodbasics.ca/sitemap.xml"]
+    sitemap_rules = [(r"/p/(\d+)$", "parse_sd")]
+
+    custom_settings = {
+        "TWISTED_REACTOR": "twisted.internet.asyncioreactor.AsyncioSelectorReactor",
+        "DOWNLOAD_HANDLERS": {
+            "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+            "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+        },
+        "PLAYWRIGHT_BROWSER_TYPE": "firefox",
+        "PLAYWRIGHT_DEFAULT_NAVIGATION_TIMEOUT": 60 * 1000,
+        "PLAYWRIGHT_LAUNCH_OPTIONS": {
+            "headless": True,
+        },
+        "ROBOTSTXT_OBEY": False,
+        "USER_AGENT": FIREFOX_LATEST,
+        "CONCURRENT_REQUESTS": 1,
+        "DOWNLOAD_DELAY": 3.0,
+        "DEFAULT_REQUEST_HEADERS": {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Accept-Language": "en-CA,en-US;q=0.9,en;q=0.8,fr-CA;q=0.7,fr;q=0.6",
+        },
+    }
+
+    item_attributes = {
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q5465300",
+                "name": "Food Basics",
+            }
+        }
+    }
+
+    def start_requests(self):
+        # Allow testing a single URL if specified
+        if hasattr(self, "urls"):
+            urls = self.urls.split(",") if isinstance(self.urls, str) else self.urls
+            for url in urls:
+                yield Request(url, self.parse_sd, meta={"playwright": True})
+            return
+
+        for url in self.sitemap_urls:
+            yield Request(url, self._parse_sitemap, meta={"playwright": True})
+
+    def _parse_sitemap(self, response):
+        """
+        Ensure subsequent requests from the sitemap also use Playwright.
+        """
+        for request_or_item in super()._parse_sitemap(response):
+            if isinstance(request_or_item, Request):
+                request_or_item.meta["playwright"] = True
+                yield request_or_item
+            else:
+                yield request_or_item


### PR DESCRIPTION
This pull request implements a web scraper for Food Basics (Canada) (https://www.foodbasics.ca) as requested in Issue #464.

### Key Changes
- Created `products/spiders/foodbasics_ca.py` with `FoodbasicsCASpider` inheriting from `SitemapSpider` and `StructuredDataSpider`.
- Configured sitemap discovery pointing to `https://www.foodbasics.ca/sitemap.xml` with sitemap rules to match product pages matching `/p/(\d+)$`.
- Configured Scrapy-Playwright with Firefox browser engine and added custom polite crawling settings (`CONCURRENT_REQUESTS = 1`, `DOWNLOAD_DELAY = 3.0`) to avoid Cloudflare 429/403 challenges.
- Configured the seller's Wikidata ID (`Q5465300`).

### Sample Output Structured Data
```json
{
  "name": "Nacho Cheese Tacos Kit",
  "website": "https://www.foodbasics.ca/aisles/world-cuisine/latin/nacho-cheese-tacos-kit/p/058300141343",
  "image": "https://product-images.metro.ca/images/he2/hc4/15906813509662.jpg",
  "ref": "058300141343",
  "offers": [
    {
      "@type": "Offer",
      "price": "4.49",
      "priceCurrency": "CAD"
    },
    {
      "@type": "Offer",
      "price": "3.99",
      "priceCurrency": "CAD",
      "validThrough": "2026-08-05T23:59:59-04:00"
    }
  ],
  "extras": {
    "seller": {
      "@type": "Organization",
      "@id": "https://www.wikidata.org/wiki/Q5465300",
      "name": "Food Basics"
    }
  }
}
```

---
*PR created automatically by Jules for task [9136493638176984324](https://jules.google.com/task/9136493638176984324) started by @CloCkWeRX*