### PR TITLE
Add web scraper for Fareway US (Fix #462)

### DIFF
--- a/products/spiders/fareway_us.py
+++ b/products/spiders/fareway_us.py
@@ -1,0 +1,46 @@
+from scrapy.spiders import SitemapSpider
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+class FarewayUSSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Fareway (United States).
+    Wikidata: Q5434998
+    Fix #462.
+    """
+    name = "fareway_us"
+    allowed_domains = ["shop.fareway.com"]
+    sitemap_urls = ["https://shop.fareway.com/sitemaps/storefront_pro/shop_fareway_com/sitemap.xml"]
+    sitemap_rules = [
+        (r"/products/(\d+)-", "parse_sd"),
+    ]
+
+    custom_settings = {
+        "ROBOTSTXT_OBEY": False,
+        "USER_AGENT": FIREFOX_LATEST,
+    }
+
+    item_attributes = {
+        "located_in_wikidata": "Q5434998",
+        "brand_wikidata": "Q5434998",
+        "proof_currency": "USD",
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q5434998",
+                "name": "Fareway",
+            }
+        }
+    }
+
+    def sitemap_filter(self, entries):
+        for entry in entries:
+            # We only want to crawl product sitemaps
+            if "products" in entry["loc"]:
+                yield entry
+
+    def post_process_item(self, item, response, ld_data, **kwargs):
+        # Enforce currency is USD
+        item["proof_currency"] = "USD"
+        item["located_in_wikidata"] = "Q5434998"
+        yield item


### PR DESCRIPTION
Implement web scraper for Fareway US to resolve issue #462.

Uses SitemapSpider and StructuredDataSpider to scrape shop.fareway.com. Enforces USD currency and includes Fareway wikidata ID Q5434998.

Sample Output:
```json
{
  "brand_wikidata": "Q5434998",
  "extras": {
    "@source_uri": "https://shop.fareway.com/store/fareway-meat-grocery/products/94796-whink-rust-stain-remover-16-oz",
    "seller": {
      "@id": "https://www.wikidata.org/wiki/Q5434998",
      "@type": "Organization",
      "name": "Fareway"
    }
  },
  "image": "https://d2lnr5mha7bycj.cloudfront.net/product-image/file/large_30f6f967-9f40-4abe-a846-78e6057bd738.png",
  "located_in_wikidata": "Q5434998",
  "name": "Whink Rust Stain Remover",
  "offers": [
    {
      "@type": "Offer",
      "availability": "https://schema.org/InStock",
      "itemCondition": "https://schema.org/NewCondition",
      "price": "5.99",
      "priceCurrency": "USD",
      "url": "https://shop.fareway.com/store/fareway-meat-grocery/products/94796-whink-rust-stain-remover-16-oz"
    }
  ],
  "proof_currency": "USD",
  "ref": "94796",
  "website": "https://shop.fareway.com/store/fareway-meat-grocery/products/94796-whink-rust-stain-remover-16-oz"
}
```

---
*PR created automatically by Jules for task [2261386874077556202](https://jules.google.com/task/2261386874077556202) started by @CloCkWeRX*