### PR TITLE
Add Planet Organic (UK) spider (Fixes #153)

### DIFF
--- a/products/spiders/planetorganic_gb.py
+++ b/products/spiders/planetorganic_gb.py
@@ -1,0 +1,34 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+
+
+class PlanetorganicGBSpider(SitemapSpider, StructuredDataSpider):
+    """
+    Spider for Planet Organic (United Kingdom).
+    Fixes #153.
+    Wikidata: Q24298870
+
+    @url https://www.planetorganic.com/products/profusion-himalayan-pink-fine-salt-shaker-140g
+    @returns items 1
+    @scrapes name website image ref brand price proof_currency
+    """
+
+    name = "planetorganic_gb"
+    allowed_domains = ["planetorganic.com"]
+
+    item_attributes = {
+        "located_in_wikidata": "Q24298870",
+        "extras": {
+            "seller": {
+                "@type": "Organization",
+                "@id": "https://www.wikidata.org/wiki/Q24298870",
+                "name": "Planet Organic",
+            }
+        },
+    }
+
+    sitemap_urls = ["https://www.planetorganic.com/sitemap.xml"]
+    sitemap_rules = [
+        (r"/products/([^/]+)$", "parse_sd"),
+    ]


### PR DESCRIPTION
Implemented a Scrapy spider for Planet Organic UK (`planetorganic_gb`) targeting `https://www.planetorganic.com/sitemap.xml`.

Sample scraped structured data output:
```json
{
  "extras": {
    "@source_uri": "https://www.planetorganic.com/products/profusion-organic-protein-puffs-lemon-black-pepper-40g",
    "seller": {
      "@type": "Organization",
      "@id": "https://www.wikidata.org/wiki/Q24298870",
      "name": "Planet Organic"
    }
  },
  "name": "Profusion Organic Protein Puffs Lemon & Black Pepper 40g",
  "website": "https://www.planetorganic.com/products/profusion-organic-protein-puffs-lemon-black-pepper-40g",
  "image": "https://www.planetorganic.com/cdn/shop/files/47732-Fnew_2000x.jpg?v=1776273916",
  "ref": "47732",
  "offers": [
    {
      "@type": "Offer",
      "sku": "47732",
      "availability": "http://schema.org/InStock",
      "price": 2.0,
      "priceCurrency": "GBP",
      "url": "https://www.planetorganic.com/products/profusion-organic-protein-puffs-lemon-black-pepper-40g?variant=56511727698306"
    }
  ],
  "located_in_wikidata": "Q24298870"
}
```

Fixes #153

---
*PR created automatically by Jules for task [13515835596705738845](https://jules.google.com/task/13515835596705738845) started by @CloCkWeRX*