### PR TITLE
Add Auchan France spider (auchan_fr)

### DIFF
--- a/products/spiders/auchan_fr.py
+++ b/products/spiders/auchan_fr.py
@@ -1,0 +1,48 @@
+from scrapy.spiders import SitemapSpider
+
+from products.structured_data_spider import StructuredDataSpider
+from products.user_agents import FIREFOX_LATEST
+
+
+class AuchanFRSpider(SitemapSpider, StructuredDataSpider):
+    name = "auchan_fr"
+    allowed_domains = ["auchan.fr"]
+    user_agent = FIREFOX_LATEST
+    convert_microdata = True
+
+    sitemap_urls = ["https://www.auchan.fr/sitemaps/sitemap-products.xml"]
+    sitemap_follow = [r"sitemap-products.*\.xml"]
+    sitemap_rules = [
+        (r"/pr-([A-Z0-9]+)$", "parse_sd"),
+    ]
+
+    item_attributes = {
+        "proof_currency": "EUR",
+        "located_in_wikidata": "Q758603",
+    }
+
+    def post_process_item(self, item, response, ld_data):
+        if not item.get("proof_currency"):
+            item["proof_currency"] = "EUR"
+
+        # Check nested offers if top-level price is missing
+        if not item.get("price"):
+            offers = ld_data.get("offers") if isinstance(ld_data, dict) else None
+            if isinstance(offers, list) and len(offers) > 0:
+                offer = offers[0]
+            elif isinstance(offers, dict):
+                offer = offers
+            else:
+                offer = {}
+
+            price = offer.get("price")
+            if price is not None:
+                try:
+                    item["price"] = float(str(price).replace(",", "."))
+                except ValueError:
+                    pass
+
+            if offer.get("priceCurrency"):
+                item["proof_currency"] = offer.get("priceCurrency")
+
+        yield item


### PR DESCRIPTION
Implement web scraper spider for Auchan France (`https://www.auchan.fr/`, Wikidata Q758603).

Fixes #103

Sample output structured data:
```json
{
  "name": "Étagère d'évier en bambou 3 en 1",
  "website": "https://www.auchan.fr/etagere-d-evier-en-bambou-3-en-1/pr-C1178664",
  "image": "https://cdn.auchan.fr/media/39194fdf-d9eb-4fc4-b79c-256c915fceca_0x0/B2CD/",
  "ref": "C1178664",
  "offers": [
    {
      "@type": "Offer",
      "price": "24.99",
      "priceCurrency": "EUR",
      "priceValidUntil": "2027-08-30",
      "availability": "https://schema.org/InStock"
    }
  ],
  "proof_currency": "EUR",
  "price": 24.99,
  "located_in_wikidata": "Q758603"
}
```

---
*PR created automatically by Jules for task [4642052030547102310](https://jules.google.com/task/4642052030547102310) started by @CloCkWeRX*